### PR TITLE
Feature/bundle options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ test/mock_api_server/__pycache__
 
 vendor
 terraform-provider-instaclustr
+.idea
+terraform-provider-instaclustr_v*
+*.tfstate
+*.tfstate.*
+examples/crash.log
+examples/.terraform

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=0.0.1
+VERSION=0.1.0
 
 .PHONY: install clean all build test testacc
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,51 +1,51 @@
 provider "instaclustr" {
-    username = "<Your instaclustr username here>"
-    api_key = "<Your provisioning API key here>"
+  username = "<Your instaclustr username here>"
+  api_key = "<Your provisioning API key here>"
 }
 
 resource "instaclustr_cluster" "example2" {
-    cluster_name = "testcluster"
-    node_size = "t3.small"
-    data_centre = "US_WEST_2"
-    sla_tier = "NON_PRODUCTION"
-    cluster_network = "192.168.0.0/18"
-    private_network_cluster = false
-    cluster_provider = {
-        name = "AWS_VPC"
+  cluster_name = "testcluster"
+  node_size = "t3.small"
+  data_centre = "US_WEST_2"
+  sla_tier = "NON_PRODUCTION"
+  cluster_network = "192.168.0.0/18"
+  private_network_cluster = false
+  cluster_provider = {
+    name = "AWS_VPC"
+  }
+  rack_allocation = {
+    number_of_racks = 3
+    nodes_per_rack = 1
+  }
+  bundles = [
+    {
+      bundle = "APACHE_CASSANDRA"
+      version = "3.11.4"
+    },
+    {
+      bundle = "SPARK"
+      version = "apache-spark:2.3.2"
+    },
+    {
+      bundle = "ZEPPELIN"
+      version = "apache-zeppelin:0.8.0-spark-2.3.2"
     }
-    rack_allocation = {
-        number_of_racks = 3
-        nodes_per_rack = 1
-    }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        },
-        {
-            bundle = "SPARK"
-            version = "apache-spark:2.3.2"
-        },
-        {
-            bundle = "ZEPPELIN"
-            version = "apache-zeppelin:0.8.0-spark-2.3.2"
-        }
-    ]
+  ]
 }
 
 resource "instaclustr_firewall_rule" "test3" {
-    cluster_id = "${instaclustr_cluster.example2.id}"
-    rule_cidr = "10.1.0.0/16"
-    rules = [
-        { 
-            type = "CASSANDRA"
-        }
-    ]
+  cluster_id = "${instaclustr_cluster.example2.id}"
+  rule_cidr = "10.1.0.0/16"
+  rules = [
+    {
+      type = "CASSANDRA"
+    }
+  ]
 }
 
 resource "instaclustr_vpc_peering" "example_vpc_peering" {
-    cluster_id = "${instaclustr_cluster.example.cluster_id}"
-    peer_vpc_id = "vpc-123456"
-    peer_account_id = "1234567890"
-    peer_subnet = "10.0.0.0/20"
+  cluster_id = "${instaclustr_cluster.example.cluster_id}"
+  peer_vpc_id = "vpc-123456"
+  peer_account_id = "1234567890"
+  peer_subnet = "10.0.0.0/20"
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -17,20 +17,20 @@ resource "instaclustr_cluster" "example2" {
     number_of_racks = 3
     nodes_per_rack = 1
   }
-  bundles = [
-    {
-      bundle = "APACHE_CASSANDRA"
-      version = "3.11.4"
-    },
-    {
-      bundle = "SPARK"
-      version = "apache-spark:2.3.2"
-    },
-    {
-      bundle = "ZEPPELIN"
-      version = "apache-zeppelin:0.8.0-spark-2.3.2"
-    }
-  ]
+  bundle {
+    bundle = "APACHE_CASSANDRA"
+    version = "3.11.4"
+  }
+
+  bundle {
+    bundle = "SPARK"
+    version = "apache-spark:2.3.2"
+  }
+
+  bundle {
+    bundle = "ZEPPELIN"
+    version = "apache-zeppelin:0.8.0-spark-2.3.2"
+  }
 }
 
 resource "instaclustr_firewall_rule" "test3" {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -17,9 +17,13 @@ resource "instaclustr_cluster" "example2" {
     number_of_racks = 3
     nodes_per_rack = 1
   }
+
   bundle {
     bundle = "APACHE_CASSANDRA"
     version = "3.11.4"
+    options = {
+      auth_n_authz = true
+    }
   }
 
   bundle {

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/hashicorp/terraform v0.12.9
+	github.com/mitchellh/mapstructure v1.1.2
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 )

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -201,6 +201,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		NodeSize:              d.Get("node_size").(string),
 		DataCentre:            d.Get("data_centre").(string),
 		ClusterNetwork:        d.Get("cluster_network").(string),
+		PrivateNetworkCluster: fmt.Sprintf("%v", d.Get("private_network_cluster")),
 		RackAllocation:        rackAllocation,
 	}
 

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -238,8 +238,8 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cluster_provider", before)
 	before, _ = d.GetChange("rack_allocation")
 	d.Set("rack_allocation", before)
-	before, _ = d.GetChange("bundles")
-	d.Set("bundles", before)
+	before, _ = d.GetChange("bundle")
+	d.Set("bundle", before)
 	log.Printf("[INFO] Fetched cluster %s info from the remote server.", cluster.ID)
 	return nil
 }

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -120,6 +120,50 @@ func resourceCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"options": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"auth_n_authz": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"client_encryption": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"use_private_broadcast_rpc_address": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"lucene_enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"continuous_backup_enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"number_partitions": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"auto_create_topics": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"delete_topics": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"password_authentication": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -106,12 +106,21 @@ func resourceCluster() *schema.Resource {
 				},
 			},
 
-			"bundles": {
+			"bundle": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeMap,
-					Elem: schema.TypeString,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bundle": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
 				},
 			},
 		},
@@ -266,7 +275,7 @@ func getMapPropertyFromResourceData(d *schema.ResourceData, propertyKey string) 
 
 func getBundles(d *schema.ResourceData) []Bundle {
 	bundles := make([]Bundle, 0)
-	for _, inBundle := range d.Get("bundles").([]interface{}) {
+	for _, inBundle := range d.Get("bundle").([]interface{}) {
 		aBundle := make(map[string]string)
 		for key, value := range inBundle.(map[string]interface{}) {
 			strKey := fmt.Sprintf("%v", key)

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -262,12 +262,11 @@ func getMapPropertyFromResourceData(d *schema.ResourceData, propertyKey string) 
 	propertyVal := d.Get(propertyKey).(map[string]interface{})
 	keyToValPointerDict := make(map[string]*string)
 	for key, value := range propertyVal {
-		strKey := fmt.Sprintf("%v", key)
 		strValue := fmt.Sprintf("%v", value)
 		if strValue != "" {
-			keyToValPointerDict[strKey] = &strValue
+			keyToValPointerDict[key] = &strValue
 		} else {
-			keyToValPointerDict[strKey] = nil
+			keyToValPointerDict[key] = nil
 		}
 	}
 	return keyToValPointerDict
@@ -278,9 +277,8 @@ func getBundles(d *schema.ResourceData) []Bundle {
 	for _, inBundle := range d.Get("bundle").([]interface{}) {
 		aBundle := make(map[string]string)
 		for key, value := range inBundle.(map[string]interface{}) {
-			strKey := fmt.Sprintf("%v", key)
 			strValue := fmt.Sprintf("%v", value)
-			aBundle[strKey] = strValue
+			aBundle[key] = strValue
 		}
 		bundle := Bundle{
 			Bundle:  aBundle["bundle"],

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/mapstructure"
 )
 
 func resourceCluster() *schema.Resource {
@@ -320,15 +321,30 @@ func getBundles(d *schema.ResourceData) []Bundle {
 	bundles := make([]Bundle, 0)
 	for _, inBundle := range d.Get("bundle").([]interface{}) {
 		aBundle := make(map[string]string)
+		var bundleOptions BundleOptions
 		for key, value := range inBundle.(map[string]interface{}) {
-			strValue := fmt.Sprintf("%v", value)
-			aBundle[key] = strValue
+			if key == "options" {
+				bundleOptions = getBundleOptions(value)
+			} else {
+				strValue := fmt.Sprintf("%v", value)
+				aBundle[key] = strValue
+			}
 		}
 		bundle := Bundle{
 			Bundle:  aBundle["bundle"],
 			Version: aBundle["version"],
+			Options: bundleOptions,
 		}
 		bundles = append(bundles, bundle)
 	}
 	return bundles
+}
+
+func getBundleOptions(bOptions interface{}) BundleOptions {
+	var options BundleOptions
+	err := mapstructure.Decode(bOptions.(map[string]interface{}), &options)
+	if err == nil {
+		return options
+	}
+	return options
 }

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -107,6 +107,16 @@ func resourceCluster() *schema.Resource {
 				},
 			},
 
+			"bundles": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: schema.TypeString,
+				},
+				Removed: "Please change bundles argument -> bundle blocks (example under example/main.tf), and to avoid causing an update to the existing tfstate - replace all keys named 'bundles' with 'bundle' in resources with the provider 'provider.instaclustr'",
+			},
+
 			"bundle": {
 				Type:     schema.TypeList,
 				Required: true,

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -45,6 +45,7 @@ type CreateRequest struct {
 	NodeSize              string          `json:"nodeSize"`
 	DataCentre            string          `json:"dataCentre"`
 	ClusterNetwork        string          `json:"clusterNetwork"`
+	PrivateNetworkCluster string          `json:"privateNetworkCluster"`
 	RackAllocation        RackAllocation  `json:"rackAllocation"`
 }
 

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -10,8 +10,21 @@ type RuleType struct {
 }
 
 type Bundle struct {
-	Bundle  string `json:"bundle"`
-	Version string `json:"version"`
+	Bundle  string        `json:"bundle"`
+	Version string        `json:"version"`
+	Options BundleOptions `json:"options,omitempty"`
+}
+
+type BundleOptions struct {
+	AuthnAuthz                    string `json:"authnAuthz,omitempty" mapstructure:"auth_n_authz"`
+	ClientEncryption              string `json:"clientEncryption,omitempty" mapstructure:"client_encryption"`
+	UsePrivateBroadcastRpcAddress string `json:"usePrivateBroadcastRPCAddress,omitempty" mapstructure:"use_private_broadcast_rpc_address"`
+	LuceneEnabled                 string `json:"luceneEnabled,omitempty" mapstructure:"lucene_enabled"`
+	ContinuousBackupEnabled       string `json:"continuousBackupEnabled,omitempty" mapstructure:"continuous_backup_enabled"`
+	NumberPartitions              string `json:"numberPartitions,omitempty" mapstructure:"number_partitions"`
+	AutoCreateTopics              string `json:"autoCreateTopics,omitempty" mapstructure:"auto_create_topics"`
+	DeleteTopics                  string `json:"deleteTopics,omitempty" mapstructure:"delete_topics"`
+	PasswordAuthentication        string `json:"passwordAuthentication,omitempty" mapstructure:"password_authentication"`
 }
 
 type ClusterProvider struct {

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -10,9 +10,9 @@ type RuleType struct {
 }
 
 type Bundle struct {
-	Bundle  string        `json:"bundle"`
-	Version string        `json:"version"`
-	Options BundleOptions `json:"options,omitempty"`
+	Bundle  string        `json:"bundle" mapstructure:"bundle"`
+	Version string        `json:"version" mapstructure:"version"`
+	Options BundleOptions `json:"options,omitempty" mapstructure:"options"`
 }
 
 type BundleOptions struct {
@@ -28,24 +28,24 @@ type BundleOptions struct {
 }
 
 type ClusterProvider struct {
-	Name        *string `json:"name"`
-	AccountName *string `json:"accountName"`
+	Name        *string `json:"name" mapstructure:"name"`
+	AccountName *string `json:"accountName, omitempty" mapstructure:"account_name"`
 }
 
 type RackAllocation struct {
-	NumberOfRacks string `json:"numberOfRacks"`
-	NodesPerRack  string `json:"nodesPerRack"`
+	NumberOfRacks string `json:"numberOfRacks" mapstructure:"number_of_racks"`
+	NodesPerRack  string `json:"nodesPerRack" mapstructure:"nodes_per_rack"`
 }
 
 type CreateRequest struct {
-	ClusterName    string          `json:"clusterName"`
-	Bundles        []Bundle        `json:"bundles"`
-	Provider       ClusterProvider `json:"provider"`
-	SlaTier        string          `json:"slaTier"`
-	NodeSize       string          `json:"nodeSize"`
-	DataCentre     string          `json:"dataCentre"`
-	ClusterNetwork string          `json:"clusterNetwork"`
-	RackAllocation RackAllocation  `json:"rackAllocation"`
+	ClusterName           string          `json:"clusterName"`
+	Bundles               []Bundle        `json:"bundles"`
+	Provider              ClusterProvider `json:"provider"`
+	SlaTier               string          `json:"slaTier"`
+	NodeSize              string          `json:"nodeSize"`
+	DataCentre            string          `json:"dataCentre"`
+	ClusterNetwork        string          `json:"clusterNetwork"`
+	RackAllocation        RackAllocation  `json:"rackAllocation"`
 }
 
 type Cluster struct {

--- a/test/data/invalid.tf
+++ b/test/data/invalid.tf
@@ -17,18 +17,19 @@ resource "instaclustr_cluster" "invalid" {
         number_of_racks = 3
         nodes_per_rack = 1
     }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        },
-        {
-            bundle = "SPARK"
-            version = "apache-spark:2.3.2"
-        },
-        {
-            bundle = "ZEPPELIN"
-            version = "apache-zeppelin:0.8.0-spark-2.3.2"
-        }
-    ]
+
+    bundle {
+        bundle = "APACHE_CASSANDRA"
+        version = "3.11.4"
+    }
+
+    bundle {
+        bundle = "SPARK"
+        version = "apache-spark:2.3.2"
+    }
+
+    bundle {
+        bundle = "ZEPPELIN"
+        version = "apache-zeppelin:0.8.0-spark-2.3.2"
+    }
 }

--- a/test/data/invalid_with_wrong_bundle_option.tf
+++ b/test/data/invalid_with_wrong_bundle_option.tf
@@ -3,7 +3,7 @@ provider "instaclustr" {
     api_key = "%s"
 }
 
-resource "instaclustr_cluster" "valid" {
+resource "instaclustr_cluster" "invalid" {
     cluster_name = "testcluster"
     node_size = "t3.small"
     data_centre = "US_WEST_2"
@@ -22,10 +22,7 @@ resource "instaclustr_cluster" "valid" {
         bundle = "APACHE_CASSANDRA"
         version = "3.11.4"
         options = {
-            auth_n_authz = true
-            use_private_broadcast_rpc_address = true
-            lucene_enabled = true
-            continuous_backup_enabled = true
+            client_encryption = true
         }
     }
 

--- a/test/data/valid.tf
+++ b/test/data/valid.tf
@@ -17,18 +17,19 @@ resource "instaclustr_cluster" "valid" {
         number_of_racks = 3
         nodes_per_rack = 1
     }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        },
-        {
-            bundle = "SPARK"
-            version = "apache-spark:2.3.2"
-        },
-        {
-            bundle = "ZEPPELIN"
-            version = "apache-zeppelin:0.8.0-spark-2.3.2"
-        }
-    ]
+
+    bundle {
+        bundle = "APACHE_CASSANDRA"
+        version = "3.11.4"
+    }
+
+    bundle {
+        bundle = "SPARK"
+        version = "apache-spark:2.3.2"
+    }
+
+    bundle {
+        bundle = "ZEPPELIN"
+        version = "apache-zeppelin:0.8.0-spark-2.3.2"
+    }
 }

--- a/test/data/valid_with_firewall_rule.tf
+++ b/test/data/valid_with_firewall_rule.tf
@@ -17,12 +17,10 @@ resource "instaclustr_cluster" "valid_with_firewall_rule" {
         number_of_racks = 3
         nodes_per_rack = 1
     }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        }
-    ]
+    bundle {
+        bundle = "APACHE_CASSANDRA"
+        version = "3.11.4"
+    }
 }
 
 resource "instaclustr_firewall_rule" "valid_with_firewall_rule" {

--- a/test/data/valid_with_resizable_cluster.tf
+++ b/test/data/valid_with_resizable_cluster.tf
@@ -17,10 +17,8 @@ resource "instaclustr_cluster" "resizable_cluster" {
         number_of_racks = 3
         nodes_per_rack = 1
     }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        }
-    ]
+    bundle {
+        bundle = "APACHE_CASSANDRA"
+        version = "3.11.4"
+    }
 }

--- a/test/data/valid_with_vpc_peering.tf
+++ b/test/data/valid_with_vpc_peering.tf
@@ -17,12 +17,10 @@ resource "instaclustr_cluster" "valid_with_vpc_peering" {
         number_of_racks = 3
         nodes_per_rack = 1
     }
-    bundles = [
-        {
-            bundle = "APACHE_CASSANDRA"
-            version = "3.11.4"
-        }
-    ]
+    bundle {
+        bundle = "APACHE_CASSANDRA"
+        version = "3.11.4"
+    }
 }
 
 resource "instaclustr_vpc_peering" "valid_with_vpc_peering" {

--- a/test/resource_cluster_test.go
+++ b/test/resource_cluster_test.go
@@ -111,6 +111,26 @@ func TestAccClusterInvalid(t *testing.T) {
 	})
 }
 
+func TestAccClusterInvalidBundleOptionCombo(t *testing.T) {
+	testAccProvider := instaclustr.Provider()
+	testAccProviders := map[string]terraform.ResourceProvider{
+		"instaclustr": testAccProvider,
+	}
+	validConfig, _ := ioutil.ReadFile("data/invalid_with_wrong_bundle_option.tf")
+	username := os.Getenv("IC_USERNAME")
+	apiKey := os.Getenv("IC_API_KEY")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(string(validConfig), username, apiKey),
+				ExpectError: regexp.MustCompile("Error creating cluster"),
+			},
+		},
+	})
+}
+
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("IC_USERNAME"); v == "" {
 		t.Fatal("IC_USERNAME for provisioning API must be set for acceptance tests")


### PR DESCRIPTION
Resolves #9 

- Adds bundle options to the schema. 
- Breaking change in the schema (bundles argument -> bundle blocks), and is reflected in the new schema and the README. Migration steps included.
- Fixed private_network_cluster
- New lib added - maptstructure. Some bits refactored to use this instead of manual mapping using string key-val dicts.