### PR TITLE
Fix VPC Peering hanging issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=v1.2.0
+VERSION=v1.2.1
 
 .PHONY: install clean all build test testacc
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ resource "instaclustr_firewall_rule" "example" {
 ```
 
 ### Resource: `instaclustr_vpc_peering`  
-A resource for managing VPC peering connections on Instaclustr Managed Platform. This is only avaliable for clusters hosted with the AWS provider.
+A resource for managing VPC peering connections on Instaclustr Managed Platform. This is only avaliable for clusters hosted with the AWS provider.  
+  
+When creating this resource, the process will wait for target cluster to be in the `PROVISIONED` or `RUNNING` status. The process will time out after 60 seconds of waiting. 
 
 #### Properties
 Property | Description | Default

--- a/instaclustr/resource_vpc_peering.go
+++ b/instaclustr/resource_vpc_peering.go
@@ -64,17 +64,24 @@ func resourceVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating VPC peering request.")
 	client := meta.(*Config).Client
 
+	const ClusterReadInterval = 5
+	const WaitForClusterTimeout = 60
 	var cdcID string
+	timePassed := 0
 	for {
 		cluster, err := client.ReadCluster(d.Get("cluster_id").(string))
 		if err != nil {
 			return fmt.Errorf("[Error] Error retrieving cluster info: %s", err)
 		}
-		if cluster.ClusterStatus == "PROVISIONED" {
+		if cluster.ClusterStatus == "PROVISIONED" || cluster.ClusterStatus == "RUNNING" {
 			cdcID = cluster.DataCentres[0].ID
 			break
 		}
-		time.Sleep(5 * time.Second)
+		if timePassed > WaitForClusterTimeout {
+			return fmt.Errorf("[Error] Timed out waiting for cluster to have the status 'PROVISIONED' or 'RUNNING'")
+		}
+		time.Sleep(ClusterReadInterval * time.Second)
+		timePassed += ClusterReadInterval
 	}
 
 	createData := CreateVPCPeeringRequest{

--- a/instaclustr/resource_vpc_peering.go
+++ b/instaclustr/resource_vpc_peering.go
@@ -67,18 +67,20 @@ func resourceVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error {
 	const ClusterReadInterval = 5
 	const WaitForClusterTimeout = 60
 	var cdcID string
+	var latestStatus string
 	timePassed := 0
 	for {
 		cluster, err := client.ReadCluster(d.Get("cluster_id").(string))
 		if err != nil {
 			return fmt.Errorf("[Error] Error retrieving cluster info: %s", err)
 		}
+		latestStatus = cluster.ClusterStatus
 		if cluster.ClusterStatus == "PROVISIONED" || cluster.ClusterStatus == "RUNNING" {
 			cdcID = cluster.DataCentres[0].ID
 			break
 		}
 		if timePassed > WaitForClusterTimeout {
-			return fmt.Errorf("[Error] Timed out waiting for cluster to have the status 'PROVISIONED' or 'RUNNING'")
+			return fmt.Errorf("[Error] Timed out waiting for cluster to have the status 'PROVISIONED' or 'RUNNING'. Current cluster status is '%s'", latestStatus)
 		}
 		time.Sleep(ClusterReadInterval * time.Second)
 		timePassed += ClusterReadInterval


### PR DESCRIPTION
Resolves #31 

Fixes an infinite loop on vpc peeering with clusters that are not in the "PROVISIONED" status.
A timeout has also been added with an appropriate fail message.