### PR TITLE
Wait for cluster to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ pci_compliant_cluster|Accepts true/false. Creates the cluster with PCI complianc
 cluster_provider|The information of infrastructure provider. See below for its properties.|Required
 rack_allocation|The number of resources to use. See below for its properties.|Optional, but Required for all Bundle types excluding Redis.
 bundle|Array of bundle information. See below for its properties.|Required
+wait_for|Wait for given cluster state. Available states: `RUNNING`, `PROVISIONED`|""
 
 `cluster_provider`
 

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -110,15 +110,15 @@ type DataCentre struct {
 }
 
 type Node struct {
-	ID             string   `json:"id"`
-	Size           string   `json:"size"`
-	Rack           string   `json:"rack"`
-	PublicAddress  []string `json:"publicAddress"`
-	PrivateAddress []string `json:"privateAddress"`
-	NodeStatus     string   `json:"nodeStatus"`
-	SparkMaster    bool     `json:"sparkMaster"`
-	SparkJobserver bool     `json:"sparkJobserver"`
-	Zeppelin       bool     `json:"zeppelin"`
+	ID             string `json:"id"`
+	Size           string `json:"size"`
+	Rack           string `json:"rack"`
+	PublicAddress  string `json:"publicAddress"`
+	PrivateAddress string `json:"privateAddress"`
+	NodeStatus     string `json:"nodeStatus"`
+	SparkMaster    bool   `json:"sparkMaster"`
+	SparkJobserver bool   `json:"sparkJobserver"`
+	Zeppelin       bool   `json:"zeppelin"`
 }
 
 type CreateVPCPeeringRequest struct {


### PR DESCRIPTION
This PR is based on #51.
In addition, the `instaclustr_cluster` will wait until the cluster will be in the running state. Solves #49. Also, it allows us to read the public and private IP addresses, eg. when a DNS entry has to be created using those IPs.

Additional parameters were added:
- `data_centre_id` - useful when creating VPC peering in GCP
- `cluster_certificate_download`
- `instaclustr_user_password`