### PR TITLE
Add provider variable to kms encryption keys, fix cluster tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=v1.5.1
+VERSION=v1.6.0
 
 .PHONY: install clean all build test testacc
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=v1.5.0
+VERSION=v1.5.1
 
 .PHONY: install clean all build test testacc
 

--- a/README.md
+++ b/README.md
@@ -238,17 +238,8 @@ key_provider|For customers running in their own account. Value specifying the th
 #### Example
 ```
 resource "instaclustr_encryption_key" "example_encryption_key" {
-    alias: "virginia 1"
-    arn: "arn:aws:kms:us-east-1:123456789012:key12345678-1234-1234-1234-123456789abc"
-}
-```
-
-Example of an additional provider:
-```
-resource "instaclustr_encryption_key" "example_encryption_key" {
-    alias: "virginia 1"
-    arn: "arn:aws:kms:us-east-1:123456789012:key12345678-1234-1234-1234-123456789abc"
-    key_provider: "INSTACLUSTR"
+    alias = "virginia 1"
+    arn = "arn:aws:kms:us-east-1:123456789012:key12345678-1234-1234-1234-123456789abc"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Property | Description | Default
 key_id|Internal ID of the KMS encryption key. Can be found via GET to `https://api.instaclustr.com/provisioning/v1/encryption-keys`|""
 alias|KMS key alias, a human-readibly identifier specified alongside your KMS ARN|""
 arn|KMS ARN, identifier specifying provider, location and key in a ':' value seperated string|""
+provider|value specifying the the provider account, same as the cluster_provider|INSTACLUSTR
 
 #### Example
 ```

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Property | Description | Default
 key_id|Internal ID of the KMS encryption key. Can be found via GET to `https://api.instaclustr.com/provisioning/v1/encryption-keys`|""
 alias|KMS key alias, a human-readibly identifier specified alongside your KMS ARN|""
 arn|KMS ARN, identifier specifying provider, location and key in a ':' value seperated string|""
-key_provider|For customers running in their own account. Value specifying the the provider account’s name, similar to `instaclustr_cluster.cluster_provider.account_name`|INSTACLUSTR
+key_provider|For customers running in their own account. Value specifying the provider account’s name, similar to `instaclustr_cluster.cluster_provider.account_name`|INSTACLUSTR
 
 #### Example
 ```

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Property | Description | Default
 key_id|Internal ID of the KMS encryption key. Can be found via GET to `https://api.instaclustr.com/provisioning/v1/encryption-keys`|""
 alias|KMS key alias, a human-readibly identifier specified alongside your KMS ARN|""
 arn|KMS ARN, identifier specifying provider, location and key in a ':' value seperated string|""
-provider|value specifying the the provider account, same as the cluster_provider|INSTACLUSTR
+key_provider|value specifying the the provider account, same as the cluster_provider|INSTACLUSTR
 
 #### Example
 ```

--- a/README.md
+++ b/README.md
@@ -233,13 +233,22 @@ Property | Description | Default
 key_id|Internal ID of the KMS encryption key. Can be found via GET to `https://api.instaclustr.com/provisioning/v1/encryption-keys`|""
 alias|KMS key alias, a human-readibly identifier specified alongside your KMS ARN|""
 arn|KMS ARN, identifier specifying provider, location and key in a ':' value seperated string|""
-key_provider|value specifying the the provider account, same as the cluster_provider|INSTACLUSTR
+key_provider|value specifying the the provider account, referrences the `instaclustr_cluster.cluster_provider.account_name` object, used when creating clusters|INSTACLUSTR
 
 #### Example
 ```
 resource "instaclustr_encryption_key" "example_encryption_key" {
     alias: "virginia 1"
     arn: "arn:aws:kms:us-east-1:123456789012:key12345678-1234-1234-1234-123456789abc"
+}
+```
+
+Example of an additional provider:
+```
+resource "instaclustr_encryption_key" "example_encryption_key" {
+    alias: "virginia 1"
+    arn: "arn:aws:kms:us-east-1:123456789012:key12345678-1234-1234-1234-123456789abc"
+    key_provider: "INSTACLUSTR"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Property | Description | Default
 key_id|Internal ID of the KMS encryption key. Can be found via GET to `https://api.instaclustr.com/provisioning/v1/encryption-keys`|""
 alias|KMS key alias, a human-readibly identifier specified alongside your KMS ARN|""
 arn|KMS ARN, identifier specifying provider, location and key in a ':' value seperated string|""
-key_provider|value specifying the the provider account, referrences the `instaclustr_cluster.cluster_provider.account_name` object, used when creating clusters|INSTACLUSTR
+key_provider|For customers running in their own account. Value specifying the the provider account’s name, similar to `instaclustr_cluster.cluster_provider.account_name`|INSTACLUSTR
 
 #### Example
 ```

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -19,6 +19,9 @@ resource "instaclustr_cluster" "example2" {
   cluster_provider = {
     name = "AWS_VPC",
     disk_encryption_key = "${instaclustr_encryption_key.add_ebs_key.key_id}"
+    tags = {
+      "myTag" = "myTagValue"
+    }
   }
   rack_allocation = {
     number_of_racks = 3

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,6 +6,7 @@ provider "instaclustr" {
 resource "instaclustr_encryption_key" "add_ebs_key" {
     alias = "testkey"
     arn = "<Your KMS key ARN here>"
+    provider = "INSTACLUSTR"
 }
 
 resource "instaclustr_cluster" "example2" {

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -92,10 +92,6 @@ func resourceCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"tags": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
 						"resource_group": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -106,6 +102,11 @@ func resourceCluster() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
 			},
 
 			"rack_allocation": {
@@ -298,6 +299,8 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	clusterProvider.Tags = d.Get("tags").(map[string]interface{})
 
 	createData := CreateRequest{
 		ClusterName:           d.Get("cluster_name").(string),

--- a/instaclustr/resource_encryption_key.go
+++ b/instaclustr/resource_encryption_key.go
@@ -31,8 +31,8 @@ func resourceEncryptionKey() *schema.Resource {
 			"provider": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default: "INSTACLUSTR"
-			}
+				Default: "INSTACLUSTR",
+			},
 		},
 	}
 }
@@ -44,7 +44,7 @@ func resourceEncryptionKeyCreate(d *schema.ResourceData, meta interface{}) error
 	createData := EncryptionKey{
 		Alias: d.Get("alias").(string),
 		ARN:   d.Get("arn").(string),
-		PROVIDER: d.Get("provider").(string)
+		PROVIDER: d.Get("provider").(string),
 	}
 
 	var jsonStr []byte

--- a/instaclustr/resource_encryption_key.go
+++ b/instaclustr/resource_encryption_key.go
@@ -28,6 +28,11 @@ func resourceEncryptionKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"provider": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default: "INSTACLUSTR"
+			}
 		},
 	}
 }
@@ -39,6 +44,7 @@ func resourceEncryptionKeyCreate(d *schema.ResourceData, meta interface{}) error
 	createData := EncryptionKey{
 		Alias: d.Get("alias").(string),
 		ARN:   d.Get("arn").(string),
+		PROVIDER: d.Get("provider").(string)
 	}
 
 	var jsonStr []byte
@@ -70,6 +76,7 @@ func resourceEncryptionKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_id", keyResource.ID)
 	d.Set("alias", keyResource.Alias)
 	d.Set("arn", keyResource.ARN)
+	d.Set("provider", keyResource.PROVIDER)
 	log.Printf("[INFO] Read encyption key %s.", id)
 	return nil
 }

--- a/instaclustr/resource_encryption_key.go
+++ b/instaclustr/resource_encryption_key.go
@@ -28,7 +28,7 @@ func resourceEncryptionKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"provider": {
+			"key_provider": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default: "INSTACLUSTR",
@@ -44,7 +44,7 @@ func resourceEncryptionKeyCreate(d *schema.ResourceData, meta interface{}) error
 	createData := EncryptionKey{
 		Alias: d.Get("alias").(string),
 		ARN:   d.Get("arn").(string),
-		PROVIDER: d.Get("provider").(string),
+		Provider: d.Get("key_provider").(string),
 	}
 
 	var jsonStr []byte
@@ -76,7 +76,7 @@ func resourceEncryptionKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_id", keyResource.ID)
 	d.Set("alias", keyResource.Alias)
 	d.Set("arn", keyResource.ARN)
-	d.Set("provider", keyResource.PROVIDER)
+	d.Set("key_provider", keyResource.Provider)
 	log.Printf("[INFO] Read encyption key %s.", id)
 	return nil
 }

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -155,7 +155,7 @@ type EncryptionKey struct {
 	ID    string `json:"id,omitempty"`
 	Alias string `json:"alias,omitempty"`
 	ARN   string `json:"arn,omitempty"`
-	PROVIDER string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty"`
 }
 
 type CreateKafkaUserRequest struct {

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -56,7 +56,7 @@ type ClusterProvider struct {
 	Name                   *string `json:"name" mapstructure:"name"`
 	AccountName            *string `json:"accountName, omitempty" mapstructure:"account_name"`
 	CustomVirtualNetworkId *string `json:"customVirtualNetworkId, omitempty" mapstructure:"custom_virtual_network_id"`
-	Tags                   *string `json:"tags,omitempty" mapstructure:"tags"`
+	Tags                   map[string]interface{} `json:"tags,omitempty"`
 	ResourceGroup          *string `json:"resourceGroup,omitempty" mapstructure:"resource_group"`
 	DiskEncryptionKey      *string `json:"diskEncryptionKey,omitempty" mapstructure:"disk_encryption_key"`
 }

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -155,6 +155,7 @@ type EncryptionKey struct {
 	ID    string `json:"id,omitempty"`
 	Alias string `json:"alias,omitempty"`
 	ARN   string `json:"arn,omitempty"`
+	PROVIDER string `json:"provider,omitempty"`
 }
 
 type CreateKafkaUserRequest struct {

--- a/test/data/valid_encryption_key.tf
+++ b/test/data/valid_encryption_key.tf
@@ -7,4 +7,5 @@ provider "instaclustr" {
 resource "instaclustr_encryption_key" "valid" {
     alias = "ic_test_key"
     arn = "%s"
+    key_provider = "INSTACLUSTR"
 }


### PR DESCRIPTION
This pr provides a provider variable to the Encryption keys object. 

We also fixed an issue with tags having an incompatible type to the Instaclustr API. 