### PR TITLE
Add Cluster Credentials Data Source to allow using password and certificate download in Terraform config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=v1.7.1
+VERSION=v1.7.0
 
 .PHONY: install clean all build test testacc
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME="terraform-provider-instaclustr"
-VERSION=v1.6.1
+VERSION=v1.7.1
 
 .PHONY: install clean all build test testacc
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,14 @@ resource "instaclustr_cluster" "example" {
 
 ## Configuration
 ### Resources
-### Resource:  `instaclustr_cluster`  
-A resource for managing clusters on Instaclustr Managed Platform. A cluster contains a base application and several add-ons.
+### Resource:  `instaclustr_cluster` and Data Source `instaclustr_cluster_credentials`
+Resources for managing clusters on Instaclustr Managed Platform. 
+A cluster contains a base application and several add-ons.
+Cluster credentials is a read-only data source used to get the password and certifcate download link of a cluster.
 
 #### Properties
+`instaclustr_cluster`
+
 Property | Description | Default
 ---------|-------------|--------
 cluster_name|The name of new cluster. May contain a combination of letters, numbers and underscores with a maximum length of 32 characters.|Required
@@ -166,6 +170,14 @@ replica_nodes|The number of Replica nodes in a generated Redis Cluster.|Redis|Re
 dedicated_zookeeper|Indicate whether this Kafka cluster should allocate dedicated Zookeeper nodes|Kafka|false
 zookeeper_node_size|If `dedicated_zookeeper` is true, then it is the node size for the dedicated Zookeeper nodes. Have a look [here](https://www.instaclustr.com/support/api-integrations/api-reference/provisioning-api/#section-create-cluster) (Kafka bundle options table) for node size options. |Kafka
 zookeeper_node_count|If `dedicated_zookeeper` is true, then it indicates how many nodes are allocated to be Zookeeper nodes|Kafka
+
+`instaclustr_cluster_credentials`
+
+Property | Description | Default
+---------|-------------|--------
+cluster_id|The ID of an existing Instaclustr cluster.|Required
+cluster_password|The password of the existing Instaclustr cluster.|Computed
+certificate_download|The certifiacte download link of the existing Instaclustr cluster.|Computed
 
 ### Resource:  `instaclustr_firewall_rule`                             
 A resource for managing cluster firewall rules on Instaclustr Managed Platform. A firewall rule allows access to your Instaclustr cluster.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Property | Description | Default
 ---------|-------------|--------
 cluster_id|The ID of an existing Instaclustr cluster.|Required
 cluster_password|The password of the existing Instaclustr cluster.|Computed
-certificate_download|The certifiacte download link of the existing Instaclustr cluster.|Computed
+certificate_download|The certificate download link of the existing Instaclustr cluster.|Computed
 
 ### Resource:  `instaclustr_firewall_rule`                             
 A resource for managing cluster firewall rules on Instaclustr Managed Platform. A firewall rule allows access to your Instaclustr cluster.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ resource "instaclustr_cluster" "example" {
 ## Configuration
 ### Resources
 ### Resource:  `instaclustr_cluster`
-A resource for managing clusters on Instaclustr Managed Platform.  A cluster contains a base application and several add-ons.
+A resource for managing clusters on Instaclustr Managed Platform. A cluster contains a base application and several add-ons.
 
 #### Properties
 Property | Description | Default

--- a/README.md
+++ b/README.md
@@ -96,14 +96,10 @@ resource "instaclustr_cluster" "example" {
 
 ## Configuration
 ### Resources
-### Resource:  `instaclustr_cluster` and Data Source `instaclustr_cluster_credentials`
-Resources for managing clusters on Instaclustr Managed Platform. 
-A cluster contains a base application and several add-ons.
-Cluster credentials is a read-only data source used to get the password and certifcate download link of a cluster.
+### Resource:  `instaclustr_cluster`
+A resource for managing clusters on Instaclustr Managed Platform.  A cluster contains a base application and several add-ons.
 
 #### Properties
-`instaclustr_cluster`
-
 Property | Description | Default
 ---------|-------------|--------
 cluster_name|The name of new cluster. May contain a combination of letters, numbers and underscores with a maximum length of 32 characters.|Required
@@ -171,7 +167,8 @@ dedicated_zookeeper|Indicate whether this Kafka cluster should allocate dedicate
 zookeeper_node_size|If `dedicated_zookeeper` is true, then it is the node size for the dedicated Zookeeper nodes. Have a look [here](https://www.instaclustr.com/support/api-integrations/api-reference/provisioning-api/#section-create-cluster) (Kafka bundle options table) for node size options. |Kafka
 zookeeper_node_count|If `dedicated_zookeeper` is true, then it indicates how many nodes are allocated to be Zookeeper nodes|Kafka
 
-`instaclustr_cluster_credentials`
+### Data Source `instaclustr_cluster_credentials`
+A read-only data source used to get the password and certificate download link of a cluster.
 
 Property | Description | Default
 ---------|-------------|--------

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -9,6 +9,7 @@ resource "instaclustr_encryption_key" "add_ebs_key" {
     provider = "INSTACLUSTR"
 }
 
+
 resource "instaclustr_cluster" "example2" {
   cluster_name = "testcluster"
   node_size = "t3.small"
@@ -45,6 +46,10 @@ resource "instaclustr_cluster" "example2" {
     bundle = "ZEPPELIN"
     version = "apache-zeppelin:0.8.0-spark-2.3.2"
   }
+}
+
+data "instaclustr_cluster_credentials" "example_credentials" {
+  cluster_id = "${instaclustr_cluster.example2.id}"
 }
 
 resource "instaclustr_cluster" "custom_vpc_example" {

--- a/instaclustr/api_client.go
+++ b/instaclustr/api_client.go
@@ -297,27 +297,6 @@ func (c *APIClient) DeleteEncryptionKey(keyID string) error {
 	return nil
 }
 
-func (c *APIClient) ReadClusterCredentials(clusterID string) (*ClusterCredentials, error) {
-	url := fmt.Sprintf("%s/provisioning/v1/%s", c.apiServerHostname, clusterID)
-	resp, err := c.MakeRequest(url, "GET", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	bodyText, err := ioutil.ReadAll(resp.Body)
-	var clusterCredentials ClusterCredentials
-	if resp.StatusCode != 202 {
-		return nil, errors.New(fmt.Sprintf("Status code: %d, message: %s", resp.StatusCode, bodyText))
-	}
-	err = json.Unmarshal(bodyText, &clusterCredentials)
-
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not unmarshal JSON - Status code: %d, message: %s", resp.StatusCode, bodyText))
-	}
-
-	return &clusterCredentials, nil
-}
-
 func (c *APIClient) CreateKafkaUser(clusterID string, data []byte) error {
 	url := fmt.Sprintf("%s/provisioning/v1/%s/kafka/users", c.apiServerHostname, clusterID)
 	resp, err := c.MakeRequest(url, "POST", data)

--- a/instaclustr/api_client.go
+++ b/instaclustr/api_client.go
@@ -297,6 +297,27 @@ func (c *APIClient) DeleteEncryptionKey(keyID string) error {
 	return nil
 }
 
+func (c *APIClient) ReadClusterCredentials(clusterID string) (*ClusterCredentials, error) {
+	url := fmt.Sprintf("%s/provisioning/v1/%s", c.apiServerHostname, clusterID)
+	resp, err := c.MakeRequest(url, "GET", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyText, err := ioutil.ReadAll(resp.Body)
+	var clusterCredentials ClusterCredentials
+	if resp.StatusCode != 202 {
+		return nil, errors.New(fmt.Sprintf("Status code: %d, message: %s", resp.StatusCode, bodyText))
+	}
+	err = json.Unmarshal(bodyText, &clusterCredentials)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Could not unmarshal JSON - Status code: %d, message: %s", resp.StatusCode, bodyText))
+	}
+
+	return &clusterCredentials, nil
+}
+
 func (c *APIClient) CreateKafkaUser(clusterID string, data []byte) error {
 	url := fmt.Sprintf("%s/provisioning/v1/%s/kafka/users", c.apiServerHostname, clusterID)
 	resp, err := c.MakeRequest(url, "POST", data)

--- a/instaclustr/data_source_cluster_credentials.go
+++ b/instaclustr/data_source_cluster_credentials.go
@@ -12,8 +12,8 @@ func dataSourceClusterCredentials() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:     	schema.TypeString,
+				Required: 	true,
 			},
 			"cluster_password": {
 				Type:		schema.TypeString,
@@ -42,7 +42,7 @@ func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) 
 	d.SetId(fmt.Sprintf("%s-credentials", id))
 	d.Set("cluster_id", id)
 	d.Set("cluster_password", clusterCredentials.ClusterPassword)
-	d.Set("cluster_certificate_download", clusterCredentials.ClusterCertificateDownload)
+	d.Set("certificate_download", clusterCredentials.ClusterCertificateDownload)
 
 	return nil
 }

--- a/instaclustr/data_source_cluster_credentials.go
+++ b/instaclustr/data_source_cluster_credentials.go
@@ -1,0 +1,48 @@
+package instaclustr
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func dataSourceClusterCredentials() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceClusterCredentialsRead,
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cluster_password": {
+				Type:		schema.TypeString,
+				Computed:	true,
+				Sensitive:	true,
+			},
+			"certificate_download": {
+				Type:		schema.TypeString,
+				Computed:	true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Client
+	id := d.Get("cluster_id").(string)
+
+	log.Printf("[INFO] Reading credentials of cluster %s.", id)
+	clusterCredentials, err := client.ReadClusterCredentials(id)
+
+	if err != nil {
+		return fmt.Errorf("[Error] Error reading cluster credentials: #{err}")
+	}
+
+	d.SetId(fmt.Sprintf("%s-credentials", id))
+	d.Set("cluster_id", id)
+	d.Set("cluster_password", clusterCredentials.ClusterPassword)
+	d.Set("cluster_certificate_download", clusterCredentials.ClusterCertificateDownload)
+
+	return nil
+}

--- a/instaclustr/data_source_cluster_credentials.go
+++ b/instaclustr/data_source_cluster_credentials.go
@@ -33,7 +33,7 @@ func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) 
 	id := d.Get("cluster_id").(string)
 
 	log.Printf("[INFO] Reading credentials of cluster %s.", id)
-	clusterCredentials, err := client.ReadClusterCredentials(id)
+	cluster, err := client.ReadCluster(id)
 
 	if err != nil {
 		return fmt.Errorf("[Error] Error reading cluster credentials: #{err}")
@@ -41,8 +41,8 @@ func dataSourceClusterCredentialsRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(fmt.Sprintf("%s-credentials", id))
 	d.Set("cluster_id", id)
-	d.Set("cluster_password", clusterCredentials.ClusterPassword)
-	d.Set("certificate_download", clusterCredentials.ClusterCertificateDownload)
+	d.Set("cluster_password", cluster.InstaclustrUserPassword)
+	d.Set("certificate_download", cluster.ClusterCertificateDownload)
 
 	return nil
 }

--- a/instaclustr/provider.go
+++ b/instaclustr/provider.go
@@ -23,14 +23,15 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"instaclustr_cluster":         resourceCluster(),
-			"instaclustr_encryption_key":  resourceEncryptionKey(),
-			"instaclustr_firewall_rule":   resourceFirewallRule(),
-			"instaclustr_vpc_peering":     resourceVpcPeering(),
-			"instaclustr_kafka_user":      resourceKafkaUser(),
+			"instaclustr_cluster":				resourceCluster(),
+			"instaclustr_encryption_key":		resourceEncryptionKey(),
+			"instaclustr_firewall_rule":		resourceFirewallRule(),
+			"instaclustr_vpc_peering":			resourceVpcPeering(),
+			"instaclustr_kafka_user":			resourceKafkaUser(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"instaclustr_kafka_user_list": dataSourceKafkaUserList(),
+			"instaclustr_cluster_credentials":	dataSourceClusterCredentials(),
 		},
 	}
 	provider.ConfigureFunc = providerConfigure

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -446,7 +446,7 @@ func getBundles(d *schema.ResourceData) ([]Bundle, error) {
 	bundles := make([]Bundle, 0)
 	for _, inBundle := range d.Get("bundle").([]interface{}) {
 		var bundle Bundle
-		err := mapstructure.Decode(inBundle.(map[string]interface{}), &bundle)
+		err := mapstructure.WeakDecode(inBundle.(map[string]interface{}), &bundle)
 		if err != nil {
 			return nil, err
 		}

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -17,18 +17,18 @@ type Bundle struct {
 }
 
 type BundleOptions struct {
-	AuthnAuthz                    string `json:"authnAuthz,omitempty" mapstructure:"auth_n_authz"`
-	ClientEncryption              string `json:"clientEncryption,omitempty" mapstructure:"client_encryption"`
-	DedicatedMasterNodes          string `json:"dedicatedMasterNodes,omitempty" mapstructure:"dedicated_master_nodes"`
+	AuthnAuthz                    bool `json:"authnAuthz,omitempty" mapstructure:"auth_n_authz"`
+	ClientEncryption              bool `json:"clientEncryption,omitempty" mapstructure:"client_encryption"`
+	DedicatedMasterNodes          bool `json:"dedicatedMasterNodes,omitempty" mapstructure:"dedicated_master_nodes"`
 	MasterNodeSize                string `json:"masterNodeSize,omitempty" mapstructure:"master_node_size"`
-	SecurityPlugin                string `json:"securityPlugin,omitempty" mapstructure:"security_plugin"`
-	UsePrivateBroadcastRpcAddress string `json:"usePrivateBroadcastRPCAddress,omitempty" mapstructure:"use_private_broadcast_rpc_address"`
-	LuceneEnabled                 string `json:"luceneEnabled,omitempty" mapstructure:"lucene_enabled"`
-	ContinuousBackupEnabled       string `json:"continuousBackupEnabled,omitempty" mapstructure:"continuous_backup_enabled"`
+	SecurityPlugin                bool `json:"securityPlugin,omitempty" mapstructure:"security_plugin"`
+	UsePrivateBroadcastRpcAddress bool `json:"usePrivateBroadcastRPCAddress,omitempty" mapstructure:"use_private_broadcast_rpc_address"`
+	LuceneEnabled                 bool `json:"luceneEnabled,omitempty" mapstructure:"lucene_enabled"`
+	ContinuousBackupEnabled       bool `json:"continuousBackupEnabled,omitempty" mapstructure:"continuous_backup_enabled"`
 	NumberPartitions              string `json:"numberPartitions,omitempty" mapstructure:"number_partitions"`
-	AutoCreateTopics              string `json:"autoCreateTopics,omitempty" mapstructure:"auto_create_topics"`
-	DeleteTopics                  string `json:"deleteTopics,omitempty" mapstructure:"delete_topics"`
-	PasswordAuthentication        string `json:"passwordAuthentication,omitempty" mapstructure:"password_authentication"`
+	AutoCreateTopics              bool `json:"autoCreateTopics,omitempty" mapstructure:"auto_create_topics"`
+	DeleteTopics                  bool `json:"deleteTopics,omitempty" mapstructure:"delete_topics"`
+	PasswordAuthentication        bool `json:"passwordAuthentication,omitempty" mapstructure:"password_authentication"`
 	TargetKafkaClusterId          string `json:"targetKafkaClusterId,omitempty" mapstructure:"target_kafka_cluster_id"`
 	VPCType                       string `json:"vpcType,omitempty" mapstructure:"vpc_type"`
 	AWSAccessKeyId                string `json:"aws.access.key.id,omitempty" mapstructure:"aws_access_key"`
@@ -47,7 +47,7 @@ type BundleOptions struct {
 	Truststore                    string `json:"truststore,omitempty" mapstructure:"truststore"`
 	RedisMasterNodes              string `json:"masterNodes,omitempty" mapstructure:"master_nodes"`
 	RedisReplicaNodes             string `json:"replicaNodes,omitempty" mapstructure:"replica_nodes"`
-	DedicatedZookeeper            string `json:"dedicatedZookeeper,omitempty" mapstructure:"dedicated_zookeeper"`
+	DedicatedZookeeper            bool `json:"dedicatedZookeeper,omitempty" mapstructure:"dedicated_zookeeper"`
 	ZookeeperNodeSize             string `json:"zookeeperNodeSize,omitempty" mapstructure:"zookeeper_node_size"`
 	ZookeeperNodeCount            string `json:"zookeeperNodeCount,omitempty" mapstructure:"zookeeper_node_count"`
 }

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -158,6 +158,11 @@ type EncryptionKey struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+type ClusterCredentials struct {
+	ClusterPassword	string `json:"instaclustrUserPassword,omitempty"`
+	ClusterCertificateDownload string `json:"clusterCertificateDownload,omitempty"`
+}
+
 type CreateKafkaUserRequest struct {
 	Username           string `json:"username"`
 	Password           string `json:"password"`

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -158,11 +158,6 @@ type EncryptionKey struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-type ClusterCredentials struct {
-	ClusterPassword	string `json:"instaclustrUserPassword,omitempty"`
-	ClusterCertificateDownload string `json:"clusterCertificateDownload,omitempty"`
-}
-
 type CreateKafkaUserRequest struct {
 	Username           string `json:"username"`
 	Password           string `json:"password"`

--- a/test/data/valid_redis_cluster_create.tf
+++ b/test/data/valid_redis_cluster_create.tf
@@ -1,6 +1,7 @@
 provider "instaclustr" {
     username = "%s"
     api_key = "%s"
+    api_hostname = "%s"
 }
 
 resource "instaclustr_cluster" "validRedis" {

--- a/test/data/valid_with_password_and_client_encryption.tf
+++ b/test/data/valid_with_password_and_client_encryption.tf
@@ -1,0 +1,39 @@
+provider "instaclustr" {
+  username = "%s"
+  api_key = "%s"
+  api_hostname = "%s"
+}
+
+resource "instaclustr_cluster" "valid_with_password_and_client_encryption" {
+  cluster_name = "tf-provider-test-auth-n-ce"
+  node_size = "m5l-250-v2"
+  data_centre = "US_WEST_2"
+  sla_tier = "NON_PRODUCTION"
+  cluster_network = "192.168.0.0/18"
+  private_network_cluster = false
+  pci_compliant_cluster = false
+  cluster_provider = {
+    name = "AWS_VPC"
+  }
+  rack_allocation = {
+    number_of_racks = 3
+    nodes_per_rack = 1
+  }
+
+  bundle {
+    bundle = "APACHE_CASSANDRA"
+    version = "3.11.4"
+    options = {
+      auth_n_authz = true
+      use_private_broadcast_rpc_address = true
+      lucene_enabled = true
+      continuous_backup_enabled = true
+      password_authentication = true
+      client_encryption = true
+    }
+  }
+}
+
+data "instaclustr_cluster_credentials" "cluster_credentials" {
+  cluster_id = "${instaclustr_cluster.valid_with_password_and_client_encryption.id}"
+}

--- a/test/resource_kafka_user_test.go
+++ b/test/resource_kafka_user_test.go
@@ -118,7 +118,7 @@ func checkKafkaClusterRunning(hostname, username, apiKey string) resource.TestCh
 				return fmt.Errorf("[Error] Timed out waiting for cluster to have the status 'RUNNING'. Current cluster status is '%s'", latestStatus)
 			}
 			timePassed += ClusterReadInterval
-			fmt.Printf("\033[u\033[K%ds has elapsed while waiting for the cluster to reach RUNNING.", timePassed)
+			fmt.Printf("\033[u\033[K%ds has elapsed while waiting for the cluster to reach RUNNING.\n", timePassed)
 			time.Sleep(ClusterReadInterval * time.Second)
 		}
 		fmt.Printf("\n")


### PR DESCRIPTION
This PR adds a new data source that retrieves an existing cluster's password and certificate download link.
Addressing [this](https://github.com/instaclustr/terraform-provider-instaclustr/issues/24) issue