### PR TITLE
Fix for Issue #63

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             BIN_NAME="terraform-provider-instaclustr"
             FULL_BIN_NAME="${BIN_NAME}_${CIRCLE_TAG}"
             SHASUM_NAME="${BIN_NAME}_${CIRCLE_TAG:1}"
-            env GOOS=linux GOARCH=amd64 make build FLAGS="-tags netgo -a -v" VERSION=${CIRCLE_TAG}
+            env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make build FLAGS="-tags netgo -a -v" VERSION=${CIRCLE_TAG}
             zip -j bin/${FULL_BIN_NAME}_alpine_amd64.zip bin/${FULL_BIN_NAME}
             env GOOS=darwin GOARCH=amd64 make build VERSION=${CIRCLE_TAG}
             zip -j bin/${FULL_BIN_NAME}_darwin_amd64.zip bin/${FULL_BIN_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,11 @@ jobs:
             BIN_NAME="terraform-provider-instaclustr"
             FULL_BIN_NAME="${BIN_NAME}_${CIRCLE_TAG}"
             SHASUM_NAME="${BIN_NAME}_${CIRCLE_TAG:1}"
-            env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make build FLAGS="-tags netgo -a -v" VERSION=${CIRCLE_TAG}
-            zip -j bin/${FULL_BIN_NAME}_alpine_amd64.zip bin/${FULL_BIN_NAME}
             env GOOS=darwin GOARCH=amd64 make build VERSION=${CIRCLE_TAG}
             zip -j bin/${FULL_BIN_NAME}_darwin_amd64.zip bin/${FULL_BIN_NAME}
-            env GOOS=linux GOARCH=amd64 make build VERSION=${CIRCLE_TAG}
+            env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make build FLAGS="-ldflags '-w -s -extldflags \"-static\"' -tags netgo -a -v" VERSION=${CIRCLE_TAG}
             zip -j bin/${FULL_BIN_NAME}_linux_amd64.zip bin/${FULL_BIN_NAME}
+            cp bin/${FULL_BIN_NAME}_linux_amd64.zip bin/${FULL_BIN_NAME}_alpine_amd64.zip
             env GOOS=linux GOARCH=arm64 make build VERSION=${CIRCLE_TAG}
             zip -j bin/${FULL_BIN_NAME}_linux_arm64.zip bin/${FULL_BIN_NAME}
             env GOOS=linux GOARCH=arm GOARM=6 make build VERSION=${CIRCLE_TAG}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 BIN_NAME="terraform-provider-instaclustr"
 
-VERSION=v1.9.3
+VERSION=v1.9.4
 
 .PHONY: install clean all build test testacc testtarget release_version
 release_version:


### PR DESCRIPTION
I've verified that the build generated by CircleCI using the `circleci/golang:1.14` and the `-tags netgo -a -v` parameters does not work on the `runatlantis/atlantis` image.  I also verified that adding `CGO_ENABLED=0` fixes it. 

We are currently running `terraform-provider-instaclustr` with `CGO_ENABLED=0` on our CICD platform and it has work for all operations thus far.