### PR TITLE
Adding creation/management for SASL/SCRAM SHA-512 Kafka Users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME="terraform-provider-instaclustr"
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.10.1
+VERSION=1.11.0
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/acc_test/data/invalid_kafka_user_create.tf
+++ b/acc_test/data/invalid_kafka_user_create.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 2 of 4
+// This is part of testing "kafka user" suite, 4 of 4
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"
@@ -35,25 +35,10 @@ resource "instaclustr_cluster" "kafka_cluster" {
   }
 }
 
-resource "instaclustr_kafka_user" "kafka_user_charlie" {
-  cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
-  username = "%s"
-  password = "%s"
-  initial_permissions = "none"
-}
-
-resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
+resource "instaclustr_kafka_user" "kafka_user_charlie_invalid" {
   cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  options = {"sasl-scram-mechanism": "SCRAM-SHA-512"}
-}
-
-resource "instaclustr_kafka_user" "kafka_user_charlie_empty_options" {
-  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
-  username            = "%s"
-  password            = "%s"
-  initial_permissions = "none"
-  options = {}
+  options = {"sasl-scram-mechanism": "ExpectedToFail"}
 }

--- a/acc_test/data/kafka_user_create_cluster.tf
+++ b/acc_test/data/kafka_user_create_cluster.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 1 of 3
+// This is part of testing "kafka user" suite, 1 of 4
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"

--- a/acc_test/data/kafka_user_create_user.tf
+++ b/acc_test/data/kafka_user_create_user.tf
@@ -41,3 +41,19 @@ resource "instaclustr_kafka_user" "kafka_user_charlie" {
   password = "%s"
   initial_permissions = "none"
 }
+
+resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
+  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
+  username            = "%s"
+  password            = "%s"
+  initial_permissions = "none"
+  options = {"sasl-scram-mechanism": "SCRAM-SHA-512"}
+}
+
+resource "instaclustr_kafka_user" "kafka_user_charlie_empty_options" {
+  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
+  username            = "%s"
+  password            = "%s"
+  initial_permissions = "none"
+  options = {}
+}

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -42,6 +42,22 @@ resource "instaclustr_kafka_user" "kafka_user_charlie" {
   initial_permissions = "none"
 }
 
+resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
+  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
+  username            = "%s"
+  password            = "%s"
+  initial_permissions = "none"
+  options = {"sasl-scram-mechanism": "SCRAM-SHA-512"}
+}
+
+resource "instaclustr_kafka_user" "kafka_user_charlie_empty_options" {
+  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
+  username            = "%s"
+  password            = "%s"
+  initial_permissions = "none"
+  options = {}
+}
+
 data "instaclustr_kafka_user_list" "kafka_user_list" {
   cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
 }

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 3 of 3
+// This is part of testing "kafka user" suite, 3 of 4
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"

--- a/acc_test/import_resource_test.go
+++ b/acc_test/import_resource_test.go
@@ -245,7 +245,7 @@ func TestKafkaUserResource_importBasic(t *testing.T) {
 					time.Sleep(6 * time.Minute)
 				},
 				Config:      invalidResizeConfig,
-				ExpectError: regexp.MustCompile("Resize operations do not support downgrading disk sizes"),
+				ExpectError: regexp.MustCompile("There are no suitable replacement modes for cluster data centre"),
 			},
 			{
 				Config: validResizeConfig,

--- a/acc_test/resource_kafka_user_test.go
+++ b/acc_test/resource_kafka_user_test.go
@@ -105,10 +105,11 @@ func testCheckResourceValidKafka(resourceName string) resource.TestCheckFunc {
 
 func checkKafkaUserCreated(hostname, username, apiKey string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		var userResources [3]string
-		userResources[0] = "instaclustr_kafka_user.kafka_user_charlie"
-		userResources[1] = "instaclustr_kafka_user.kafka_user_charlie_scram-sha-512"
-		userResources[2] = "instaclustr_kafka_user.kafka_user_charlie_empty_options"
+		userResources := [3]string{
+			"instaclustr_kafka_user.kafka_user_charlie",
+			"instaclustr_kafka_user.kafka_user_charlie_scram-sha-512",
+			"instaclustr_kafka_user.kafka_user_charlie_empty_options",
+		}
 
 		OUTER:
 		for _, resourceName := range userResources {
@@ -136,10 +137,11 @@ func checkKafkaUserCreated(hostname, username, apiKey string) resource.TestCheck
 
 func checkKafkaUserUpdated(newPassword string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		var userResources [3]string
-		userResources[0] = "instaclustr_kafka_user.kafka_user_charlie"
-		userResources[1] = "instaclustr_kafka_user.kafka_user_charlie_scram-sha-512"
-		userResources[2] = "instaclustr_kafka_user.kafka_user_charlie_empty_options"
+		userResources := [3]string{
+			"instaclustr_kafka_user.kafka_user_charlie",
+			"instaclustr_kafka_user.kafka_user_charlie_scram-sha-512",
+			"instaclustr_kafka_user.kafka_user_charlie_empty_options",
+		}
 
 		for _, resourceName := range userResources {
 			resourceState := s.Modules[0].Resources[resourceName]

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -23,6 +23,13 @@ Property | Description | Default
 `username`|User name for the Kafka user|Required
 `password`|Password for the Kafka user|Required
 `initial_permissions`|Initial permission set (ACL) associated with this user. Possible values are: `standard`, `read-only`, and `none`. | `none`
+`options`|Additional options for Kafka user configuration (see next table for individual options)|{}
+
+N.B. The options available to be set within the `options` property above are:
+
+Option | Description | Default
+-------|-------------|--------
+`sasl-scram-mechanism`|The mechanism used to authenticate the user to the cluster. Possible values are: `SCRAM-SHA-256`, `SCRAM-SHA-512`|`SCRAM-SHA-256`
 
 `instaclustr_kafka_user_list`
 
@@ -37,6 +44,7 @@ resource "instaclustr_kafka_user" "kafka_user_charlie" {
   username = "charlie"
   password = "charlie1!"
   initial_permissions = "none"
+  options = {"sasl-scram-mechanism": "SCRAM-SHA-256"}
 }
 
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -205,6 +205,16 @@ resource "instaclustr_kafka_user" "kafka_user_charlie" {
   password = "charlie123!"
 }
 
+resource "instaclustr_kafka_user" "kafka_user_harley" {
+  cluster_id = "${instaclustr_cluster.example_kafka.id}"
+  username = "harley"
+  password = "harley123!"
+  initial_permissions = "standard"
+  options = {
+    sasl-scram-mechanism = "SCRAM-SHA-512"
+  }
+}
+
 data "instaclustr_kafka_user_list" "kafka_user_list" {
   cluster_id = "${instaclustr_cluster.example_kafka.id}"
 }

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -48,7 +48,6 @@ func resourceKafkaUser() *schema.Resource {
 			"options": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sasl-scram-mechanism": {

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -3,6 +3,7 @@ package instaclustr
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mitchellh/mapstructure"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -43,6 +44,21 @@ func resourceKafkaUser() *schema.Resource {
 				Default:  "none",
 				ForceNew: true,
 			},
+
+			"options": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"sasl-scram-mechanism": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -77,10 +93,17 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	var kafkaUserCreateOptions KafkaUserCreateOptions
+	err = mapstructure.Decode(d.Get("options").(map[string]interface{}), &kafkaUserCreateOptions)
+	if err != nil {
+		return err
+	}
+
 	createData := CreateKafkaUserRequest{
 		Username:           username,
 		Password:           d.Get("password").(string),
 		InitialPermissions: d.Get("initial_permissions").(string),
+		Options: 			&kafkaUserCreateOptions,
 	}
 
 	var jsonStr []byte
@@ -109,13 +132,21 @@ func resourceKafkaUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Changing Kafka user password in %s.", d.Get("cluster_id").(string))
 	client := meta.(*Config).Client
 
+	var err error
+	var kafkaUserResetPasswordOptions KafkaUserResetPasswordOptions
+	err = mapstructure.Decode(d.Get("options").(map[string]interface{}), &kafkaUserResetPasswordOptions)
+	if err != nil {
+		return err
+	}
+
 	createData := UpdateKafkaUserRequest{
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		Options: &kafkaUserResetPasswordOptions,
 	}
 
 	var jsonStr []byte
-	jsonStr, err := json.Marshal(createData)
+	jsonStr, err = json.Marshal(createData)
 	if err != nil {
 		return fmt.Errorf("[Error] Error creating kafka user update request: %s", err)
 	}

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -199,11 +199,21 @@ type CreateKafkaUserRequest struct {
 	Username           string `json:"username"`
 	Password           string `json:"password"`
 	InitialPermissions string `json:"initial-permissions"`
+	Options	*KafkaUserCreateOptions `json:"options,omitempty"`
+}
+
+type KafkaUserCreateOptions struct {
+	SaslScramMechanism *string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type UpdateKafkaUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
+	Options	*KafkaUserResetPasswordOptions `json:"options,omitempty"`
+}
+
+type KafkaUserResetPasswordOptions struct {
+	SaslScramMechanism *string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type DeleteKafkaUserRequest struct {


### PR DESCRIPTION
Updates the terraform provider for compatibility with the updated Instaclustr Kafka user management API. 

The API has recently had support added for a new 'options' property, within which one can specify the `sasl-scram-mechanism` with which a user's password should be authenticated -- the options being `SCRAM-SHA-256` or `SCRAM-SHA-512`. This can be set upon user creation or user password reset.

This PR allows usage of this property via the terraform provider. It also maintains backward compatibility, such that old plans and resource descriptions involving Kafka users should not be negatively affected.