### PR TITLE
Changing sasl_scram_mechanism to a top-level field for the Kafka User Resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME="terraform-provider-instaclustr"
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.11.0
+VERSION=1.11.1
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/acc_test/data/invalid_kafka_user_create.tf
+++ b/acc_test/data/invalid_kafka_user_create.tf
@@ -40,5 +40,5 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_invalid" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  options = {"sasl-scram-mechanism": "ExpectedToFail"}
+  sasl_scram_mechanism = "ExpectedToFail"
 }

--- a/acc_test/data/invalid_kafka_user_create.tf
+++ b/acc_test/data/invalid_kafka_user_create.tf
@@ -40,5 +40,5 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_invalid" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  sasl_scram_mechanism = "ExpectedToFail"
+  authentication_mechanism = "ExpectedToFail"
 }

--- a/acc_test/data/kafka_user_create_user.tf
+++ b/acc_test/data/kafka_user_create_user.tf
@@ -47,5 +47,5 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  sasl_scram_mechanism = "SCRAM-SHA-512"
+  authentication_mechanism = "SCRAM-SHA-512"
 }

--- a/acc_test/data/kafka_user_create_user.tf
+++ b/acc_test/data/kafka_user_create_user.tf
@@ -47,13 +47,5 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  options = {"sasl-scram-mechanism": "SCRAM-SHA-512"}
-}
-
-resource "instaclustr_kafka_user" "kafka_user_charlie_empty_options" {
-  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
-  username            = "%s"
-  password            = "%s"
-  initial_permissions = "none"
-  options = {}
+  sasl_scram_mechanism = "SCRAM-SHA-512"
 }

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -47,7 +47,7 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  sasl_scram_mechanism = "SCRAM-SHA-512"
+  authentication_mechanism = "SCRAM-SHA-512"
 }
 
 data "instaclustr_kafka_user_list" "kafka_user_list" {

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -47,15 +47,7 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  options = {"sasl-scram-mechanism": "SCRAM-SHA-512"}
-}
-
-resource "instaclustr_kafka_user" "kafka_user_charlie_empty_options" {
-  cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
-  username            = "%s"
-  password            = "%s"
-  initial_permissions = "none"
-  options = {}
+  sasl_scram_mechanism = "SCRAM-SHA-512"
 }
 
 data "instaclustr_kafka_user_list" "kafka_user_list" {

--- a/acc_test/resource_kafka_user_test.go
+++ b/acc_test/resource_kafka_user_test.go
@@ -28,7 +28,6 @@ func TestKafkaUserResource(t *testing.T) {
 	kafkaUsername1 := "charlie1"
 	kafkaUsername2 := "charlie2"
 	kafkaUsername3 := "charlie3"
-	kafkaUsername4 := "charlie4"
 	oldPassword := "charlie123!"
 	newPassword := "charlie123standard!"
 	zookeeperNodeSize := "zk-developer-t3.small-20"
@@ -36,18 +35,15 @@ func TestKafkaUserResource(t *testing.T) {
 	createClusterConfig := fmt.Sprintf(string(configBytes1), username, apiKey, hostname, zookeeperNodeSize)
 	createKafkaUserConfig := fmt.Sprintf(string(configBytes2), username, apiKey, hostname, zookeeperNodeSize,
 		kafkaUsername1, oldPassword,
-		kafkaUsername2, oldPassword,
-		kafkaUsername3, oldPassword)
+		kafkaUsername2, oldPassword)
 	createKafkaUserListConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
 		kafkaUsername1, oldPassword,
-		kafkaUsername2, oldPassword,
-		kafkaUsername3, oldPassword)
+		kafkaUsername2, oldPassword)
 	updateKafkaUserConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
 		kafkaUsername1, newPassword,
-		kafkaUsername2, newPassword,
-		kafkaUsername3, newPassword)
+		kafkaUsername2, newPassword)
 	invalidKafkaUserCreateConfig := fmt.Sprintf(string(configBytes4), username, apiKey, hostname, zookeeperNodeSize,
-		kafkaUsername4, oldPassword)
+		kafkaUsername3, oldPassword)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
@@ -114,10 +110,9 @@ func testCheckResourceValidKafka(resourceName string) resource.TestCheckFunc {
 
 func checkKafkaUserCreated(hostname, username, apiKey string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		userResources := [3]string{
+		userResources := [2]string{
 			"instaclustr_kafka_user.kafka_user_charlie",
 			"instaclustr_kafka_user.kafka_user_charlie_scram-sha-512",
-			"instaclustr_kafka_user.kafka_user_charlie_empty_options",
 		}
 
 		OUTER:
@@ -146,10 +141,9 @@ func checkKafkaUserCreated(hostname, username, apiKey string) resource.TestCheck
 
 func checkKafkaUserUpdated(newPassword string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		userResources := [3]string{
+		userResources := [2]string{
 			"instaclustr_kafka_user.kafka_user_charlie",
 			"instaclustr_kafka_user.kafka_user_charlie_scram-sha-512",
-			"instaclustr_kafka_user.kafka_user_charlie_empty_options",
 		}
 
 		for _, resourceName := range userResources {

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -23,7 +23,7 @@ Property | Description | Default
 `username`|User name for the Kafka user|Required
 `password`|Password for the Kafka user|Required
 `initial_permissions`|Initial permission set (ACL) associated with this user. Possible values are: `standard`, `read-only`, and `none`. | `none`
-`sasl_scram_mechanism`|The mechanism used to authenticate the user to the cluster. Possible values are: `SCRAM-SHA-256`, `SCRAM-SHA-512`|`SCRAM-SHA-256`
+`authentication_mechanism`|The mechanism used to authenticate the user to the cluster. Possible values are: `SCRAM-SHA-256`, `SCRAM-SHA-512`|`SCRAM-SHA-256`
 
 `instaclustr_kafka_user_list`
 

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -23,13 +23,7 @@ Property | Description | Default
 `username`|User name for the Kafka user|Required
 `password`|Password for the Kafka user|Required
 `initial_permissions`|Initial permission set (ACL) associated with this user. Possible values are: `standard`, `read-only`, and `none`. | `none`
-`options`|Additional options for Kafka user configuration (see next table for individual options)|{}
-
-N.B. The options available to be set within the `options` property above are:
-
-Option | Description | Default
--------|-------------|--------
-`sasl-scram-mechanism`|The mechanism used to authenticate the user to the cluster. Possible values are: `SCRAM-SHA-256`, `SCRAM-SHA-512`|`SCRAM-SHA-256`
+`sasl_scram_mechanism`|The mechanism used to authenticate the user to the cluster. Possible values are: `SCRAM-SHA-256`, `SCRAM-SHA-512`|`SCRAM-SHA-256`
 
 `instaclustr_kafka_user_list`
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -210,7 +210,7 @@ resource "instaclustr_kafka_user" "kafka_user_harley" {
   username = "harley"
   password = "harley123!"
   initial_permissions = "standard"
-  sasl_scram_mechanism = "SCRAM-SHA-512"
+  authentication_mechanism = "SCRAM-SHA-512"
 }
 
 data "instaclustr_kafka_user_list" "kafka_user_list" {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -210,9 +210,7 @@ resource "instaclustr_kafka_user" "kafka_user_harley" {
   username = "harley"
   password = "harley123!"
   initial_permissions = "standard"
-  options = {
-    sasl-scram-mechanism = "SCRAM-SHA-512"
-  }
+  sasl_scram_mechanism = "SCRAM-SHA-512"
 }
 
 data "instaclustr_kafka_user_list" "kafka_user_list" {

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -3,7 +3,6 @@ package instaclustr
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -85,12 +84,6 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var kafkaUserCreateOptions KafkaUserCreateOptions
-	err = mapstructure.Decode(d.Get("options").(map[string]interface{}), &kafkaUserCreateOptions)
-	if err != nil {
-		return err
-	}
-
 	createOptionsData := KafkaUserCreateOptions{
 		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
 	}
@@ -128,13 +121,6 @@ func resourceKafkaUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Changing Kafka user password in %s.", d.Get("cluster_id").(string))
 	client := meta.(*Config).Client
 
-	var err error
-	var kafkaUserResetPasswordOptions KafkaUserResetPasswordOptions
-	err = mapstructure.Decode(d.Get("options").(map[string]interface{}), &kafkaUserResetPasswordOptions)
-	if err != nil {
-		return err
-	}
-
 	resetPasswordOptionsData := KafkaUserResetPasswordOptions{
 		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
 	}
@@ -145,8 +131,7 @@ func resourceKafkaUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		Options: resetPasswordOptionsData,
 	}
 
-	var jsonStr []byte
-	jsonStr, err = json.Marshal(createData)
+	jsonStr, err := json.Marshal(createData)
 	if err != nil {
 		return fmt.Errorf("[Error] Error creating kafka user update request: %s", err)
 	}

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -44,7 +44,7 @@ func resourceKafkaUser() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"sasl_scram_mechanism": {
+			"authentication_mechanism": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default: "SCRAM-SHA-256",
@@ -85,7 +85,7 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	createOptionsData := KafkaUserCreateOptions{
-		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
+		AuthenticationMechanism: d.Get("authentication_mechanism").(string),
 	}
 
 	createData := CreateKafkaUserRequest{
@@ -122,7 +122,7 @@ func resourceKafkaUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).Client
 
 	resetPasswordOptionsData := KafkaUserResetPasswordOptions{
-		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
+		AuthenticationMechanism: d.Get("authentication_mechanism").(string),
 	}
 
 	createData := UpdateKafkaUserRequest{

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -45,18 +45,11 @@ func resourceKafkaUser() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"options": {
-				Type:     schema.TypeMap,
+			"sasl_scram_mechanism": {
+				Type:     schema.TypeString,
 				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"sasl-scram-mechanism": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-					},
-				},
+				Default: "SCRAM-SHA-256",
+				ForceNew: true,
 			},
 		},
 	}
@@ -98,11 +91,15 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	createOptionsData := KafkaUserCreateOptions{
+		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
+	}
+
 	createData := CreateKafkaUserRequest{
 		Username:           username,
 		Password:           d.Get("password").(string),
 		InitialPermissions: d.Get("initial_permissions").(string),
-		Options: 			&kafkaUserCreateOptions,
+		Options: 			createOptionsData,
 	}
 
 	var jsonStr []byte
@@ -138,10 +135,14 @@ func resourceKafkaUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	resetPasswordOptionsData := KafkaUserResetPasswordOptions{
+		SaslScramMechanism: d.Get("sasl_scram_mechanism").(string),
+	}
+
 	createData := UpdateKafkaUserRequest{
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
-		Options: &kafkaUserResetPasswordOptions,
+		Options: resetPasswordOptionsData,
 	}
 
 	var jsonStr []byte

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -204,7 +204,7 @@ type CreateKafkaUserRequest struct {
 }
 
 type KafkaUserCreateOptions struct {
-	SaslScramMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
+	AuthenticationMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type UpdateKafkaUserRequest struct {
@@ -214,7 +214,7 @@ type UpdateKafkaUserRequest struct {
 }
 
 type KafkaUserResetPasswordOptions struct {
-	SaslScramMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
+	AuthenticationMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type DeleteKafkaUserRequest struct {

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -200,21 +200,21 @@ type CreateKafkaUserRequest struct {
 	Username           string `json:"username"`
 	Password           string `json:"password"`
 	InitialPermissions string `json:"initial-permissions"`
-	Options	*KafkaUserCreateOptions `json:"options,omitempty"`
+	Options KafkaUserCreateOptions `json:"options,omitempty"`
 }
 
 type KafkaUserCreateOptions struct {
-	SaslScramMechanism *string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
+	SaslScramMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type UpdateKafkaUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	Options	*KafkaUserResetPasswordOptions `json:"options,omitempty"`
+	Options	KafkaUserResetPasswordOptions `json:"options,omitempty"`
 }
 
 type KafkaUserResetPasswordOptions struct {
-	SaslScramMechanism *string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
+	SaslScramMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
 }
 
 type DeleteKafkaUserRequest struct {


### PR DESCRIPTION
Moving the sasl_scram_mechanism from a nested 'options' map to being a top level field for the Kafka user resource