### PR TITLE
Kafka user override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME="terraform-provider-instaclustr"
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.12.1
+VERSION=1.13.1
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME="terraform-provider-instaclustr"
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.13.1
+VERSION=1.13.0
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/acc_test/data/invalid_kafka_user_create.tf
+++ b/acc_test/data/invalid_kafka_user_create.tf
@@ -7,7 +7,7 @@ provider "instaclustr" {
 
 resource "instaclustr_cluster" "kafka_cluster" {
   cluster_name = "example_kafka_tf_test"
-  node_size = "KFK-DEV-t4g.medium-80"
+  node_size = "%s"
   data_centre = "US_WEST_2"
   sla_tier = "NON_PRODUCTION"
   cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
 
   bundle {
     bundle = "KAFKA"
-    version = "apache-kafka:2.7.1"
+    version = "%s"
     options = {
       auto_create_topics = true
       client_encryption = false

--- a/acc_test/data/invalid_kafka_user_create_duplicate.tf
+++ b/acc_test/data/invalid_kafka_user_create_duplicate.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 4 of 5
+// This is part of testing "kafka user" suite, 5 of 5 
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"
@@ -35,10 +35,25 @@ resource "instaclustr_cluster" "kafka_cluster" {
   }
 }
 
-resource "instaclustr_kafka_user" "kafka_user_charlie_invalid" {
+resource "instaclustr_kafka_user" "kafka_user_charlie" {
+  cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
+  username = "%s"
+  password = "%s"
+  initial_permissions = "none"
+}
+
+resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   cluster_id          = "${instaclustr_cluster.kafka_cluster.id}"
   username            = "%s"
   password            = "%s"
   initial_permissions = "none"
-  authentication_mechanism = "ExpectedToFail"
+  authentication_mechanism = "SCRAM-SHA-512"
+}
+
+resource "instaclustr_kafka_user" "kafka_user_charlie_double" {
+  cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
+  username = "%s"
+  password = "%s"
+  initial_permissions = "none"
+  override_existing_user = false
 }

--- a/acc_test/data/invalid_kafka_user_create_duplicate.tf
+++ b/acc_test/data/invalid_kafka_user_create_duplicate.tf
@@ -7,7 +7,7 @@ provider "instaclustr" {
 
 resource "instaclustr_cluster" "kafka_cluster" {
   cluster_name = "example_kafka_tf_test"
-  node_size = "KFK-DEV-t4g.medium-80"
+  node_size = "%s"
   data_centre = "US_WEST_2"
   sla_tier = "NON_PRODUCTION"
   cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
 
   bundle {
     bundle = "KAFKA"
-    version = "apache-kafka:2.7.1"
+    version = "%s"
     options = {
       auto_create_topics = true
       client_encryption = false
@@ -33,7 +33,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
       zookeeper_node_count = 3
     }
   }
-}
+} 
 
 resource "instaclustr_kafka_user" "kafka_user_charlie" {
   cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
@@ -57,3 +57,4 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_double" {
   initial_permissions = "none"
   override_existing_user = false
 }
+

--- a/acc_test/data/kafka_user_create_cluster.tf
+++ b/acc_test/data/kafka_user_create_cluster.tf
@@ -7,7 +7,7 @@ provider "instaclustr" {
 
 resource "instaclustr_cluster" "kafka_cluster" {
   cluster_name = "example_kafka_tf_test"
-  node_size = "KFK-DEV-t4g.medium-80"
+  node_size = "%s"
   data_centre = "US_WEST_2"
   sla_tier = "NON_PRODUCTION"
   cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
 
   bundle {
     bundle = "KAFKA"
-    version = "apache-kafka:2.7.1"
+    version = "%s"
     options = {
       auto_create_topics = true
       client_encryption = false
@@ -34,3 +34,4 @@ resource "instaclustr_cluster" "kafka_cluster" {
     }
   }
 }
+

--- a/acc_test/data/kafka_user_create_cluster.tf
+++ b/acc_test/data/kafka_user_create_cluster.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 1 of 4
+// This is part of testing "kafka user" suite, 1 of 5
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"

--- a/acc_test/data/kafka_user_create_user.tf
+++ b/acc_test/data/kafka_user_create_user.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 2 of 4
+// This is part of testing "kafka user" suite, 2 of 5
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"

--- a/acc_test/data/kafka_user_create_user.tf
+++ b/acc_test/data/kafka_user_create_user.tf
@@ -7,7 +7,7 @@ provider "instaclustr" {
 
 resource "instaclustr_cluster" "kafka_cluster" {
   cluster_name = "example_kafka_tf_test"
-  node_size = "KFK-DEV-t4g.medium-80"
+  node_size = "%s"
   data_centre = "US_WEST_2"
   sla_tier = "NON_PRODUCTION"
   cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
 
   bundle {
     bundle = "KAFKA"
-    version = "apache-kafka:2.7.1"
+    version = "%s"
     options = {
       auto_create_topics = true
       client_encryption = false
@@ -33,13 +33,14 @@ resource "instaclustr_cluster" "kafka_cluster" {
       zookeeper_node_count = 3
     }
   }
-}
+} 
 
 resource "instaclustr_kafka_user" "kafka_user_charlie" {
   cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
   username = "%s"
   password = "%s"
   initial_permissions = "none"
+  override_existing_user = false
 }
 
 resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
@@ -48,4 +49,6 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
   password            = "%s"
   initial_permissions = "none"
   authentication_mechanism = "SCRAM-SHA-512"
+  override_existing_user = false
 }
+

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -7,7 +7,7 @@ provider "instaclustr" {
 
 resource "instaclustr_cluster" "kafka_cluster" {
   cluster_name = "example_kafka_tf_test"
-  node_size = "KFK-DEV-t4g.medium-80"
+  node_size = "%s"
   data_centre = "US_WEST_2"
   sla_tier = "NON_PRODUCTION"
   cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
 
   bundle {
     bundle = "KAFKA"
-    version = "apache-kafka:2.7.1"
+    version = "%s"
     options = {
       auto_create_topics = true
       client_encryption = false
@@ -33,7 +33,7 @@ resource "instaclustr_cluster" "kafka_cluster" {
       zookeeper_node_count = 3
     }
   }
-}
+} 
 
 resource "instaclustr_kafka_user" "kafka_user_charlie" {
   cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
@@ -53,3 +53,4 @@ resource "instaclustr_kafka_user" "kafka_user_charlie_scram-sha-512" {
 data "instaclustr_kafka_user_list" "kafka_user_list" {
   cluster_id = "${instaclustr_cluster.kafka_cluster.id}"
 }
+

--- a/acc_test/data/kafka_user_user_list.tf
+++ b/acc_test/data/kafka_user_user_list.tf
@@ -1,4 +1,4 @@
-// This is part of testing "kafka user" suite, 3 of 4
+// This is part of testing "kafka user" suite, 3 of 5
 provider "instaclustr" {
   username = "%s"
   api_key = "%s"

--- a/acc_test/data/valid_kafka.tf
+++ b/acc_test/data/valid_kafka.tf
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "valid" {
 
     bundle {
         bundle = "KAFKA"
-        version = "apache-kafka:2.7.1"
+        version = "apache-kafka:2.7.1.ic1"
         options = {
             client_encryption = false
             auto_create_topics = true

--- a/acc_test/data/valid_kafka.tf
+++ b/acc_test/data/valid_kafka.tf
@@ -5,7 +5,7 @@ provider "instaclustr" {
 }
 resource "instaclustr_cluster" "valid" {
     cluster_name = "test_cluster"
-    node_size = "KFK-PRD-r6g.large-250"
+    node_size = "%s"
     data_centre = "US_WEST_2"
     sla_tier = "NON_PRODUCTION"
     cluster_network = "192.168.0.0/18"
@@ -22,7 +22,7 @@ resource "instaclustr_cluster" "valid" {
 
     bundle {
         bundle = "KAFKA"
-        version = "apache-kafka:2.7.1.ic1"
+        version = "%s"
         options = {
             client_encryption = false
             auto_create_topics = true

--- a/acc_test/import_resource_test.go
+++ b/acc_test/import_resource_test.go
@@ -206,9 +206,11 @@ func TestKafkaUserResource_importBasic(t *testing.T) {
 	apiKey := os.Getenv("IC_API_KEY")
 	hostname := getOptionalEnv("IC_API_URL", instaclustr.DefaultApiHostname)
 
-	zookeeperNodeSize := "zk-developer-t3.small-20"
-
-	createClusterConfig := fmt.Sprintf(string(configBytes1), username, apiKey, hostname, zookeeperNodeSize)
+	kafkaNodeSize := "KFK-DEV-t4g.medium-80"
+	kafkaVersion := "apache-kafka:2.7.1.ic1"
+	zookeeperNodeSize := "KDZ-DEV-t4g.small-30"
+ 
+	createClusterConfig := fmt.Sprintf(string(configBytes1), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize)
 	validResizeConfig := strings.Replace(createClusterConfig, `KFK-DEV-t4g.medium-80`, `KFK-PRD-r6g.xlarge-800`, 1)
 	invalidResizeConfig := strings.Replace(createClusterConfig, `KFK-DEV-t4g.medium-80`, `KFK-DEV-t4g.small-30`, 1)
 	resourceName := "kafka_cluster"

--- a/acc_test/import_resource_test.go
+++ b/acc_test/import_resource_test.go
@@ -98,7 +98,11 @@ func TestAccKafkaCluster_importBasic(t *testing.T) {
 	username := os.Getenv("IC_USERNAME")
 	apiKey := os.Getenv("IC_API_KEY")
 	hostname := getOptionalEnv("IC_API_URL", instaclustr.DefaultApiHostname)
-	oriConfig := fmt.Sprintf(string(validConfig), username, apiKey, hostname)
+
+	kafkaNodeSize := "KFK-PRD-r6g.large-250"
+	kafkaVersion := "apache-kafka:2.7.1.ic1"
+
+	oriConfig := fmt.Sprintf(string(validConfig), username, apiKey, hostname, kafkaNodeSize, kafkaVersion)
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckResourceDeleted("valid", hostname, username, apiKey),

--- a/acc_test/resource_kafka_user_test.go
+++ b/acc_test/resource_kafka_user_test.go
@@ -42,6 +42,10 @@ func TestKafkaUserResource(t *testing.T) {
 	updateKafkaUserConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
 		kafkaUsername1, newPassword,
 		kafkaUsername2, newPassword)
+	invalidKafkaUserCreateConfigDuplicate := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
+		kafkaUsername1, newPassword,
+		kafkaUsername2, newPassword,
+                kafkaUsername1, newPassword)
 	invalidKafkaUserCreateConfig := fmt.Sprintf(string(configBytes4), username, apiKey, hostname, zookeeperNodeSize,
 		kafkaUsername3, oldPassword)
 
@@ -76,6 +80,10 @@ func TestKafkaUserResource(t *testing.T) {
 			{
 				Config: updateKafkaUserConfig,
 				Check:  checkKafkaUserUpdated(newPassword),
+			},
+			{
+				Config: invalidKafkaUserCreateConfigDuplicate,
+				ExpectError: regexp.MustCompile("A Kafka user with this username already exists on this cluster."),
 			},
 			// Can't rely on the resource destruction because we need the destruction to happen in order and checked,
 			// i.e., we need to destroy the kafka user resources first.

--- a/acc_test/resource_kafka_user_test.go
+++ b/acc_test/resource_kafka_user_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/instaclustr/terraform-provider-instaclustr/instaclustr"
+	
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -21,6 +22,7 @@ func TestKafkaUserResource(t *testing.T) {
 	configBytes2, _ := ioutil.ReadFile("data/kafka_user_create_user.tf")
 	configBytes3, _ := ioutil.ReadFile("data/kafka_user_user_list.tf")
 	configBytes4, _ := ioutil.ReadFile("data/invalid_kafka_user_create.tf")
+	configBytes5, _ := ioutil.ReadFile("data/invalid_kafka_user_create_duplicate.tf")
 	username := os.Getenv("IC_USERNAME")
 	apiKey := os.Getenv("IC_API_KEY")
 	hostname := getOptionalEnv("IC_API_URL", instaclustr.DefaultApiHostname)
@@ -30,23 +32,25 @@ func TestKafkaUserResource(t *testing.T) {
 	kafkaUsername3 := "charlie3"
 	oldPassword := "charlie123!"
 	newPassword := "charlie123standard!"
-	zookeeperNodeSize := "zk-developer-t3.small-20"
+	kafkaNodeSize := "KFK-DEV-t4g.medium-80"
+	zookeeperNodeSize := "KDZ-DEV-t4g.small-30"
+	kafkaVersion := "apache-kafka:2.7.1.ic1"
 
-	createClusterConfig := fmt.Sprintf(string(configBytes1), username, apiKey, hostname, zookeeperNodeSize)
-	createKafkaUserConfig := fmt.Sprintf(string(configBytes2), username, apiKey, hostname, zookeeperNodeSize,
+	createClusterConfig := fmt.Sprintf(string(configBytes1), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize)
+	createKafkaUserConfig := fmt.Sprintf(string(configBytes2), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize,
 		kafkaUsername1, oldPassword,
 		kafkaUsername2, oldPassword)
-	createKafkaUserListConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
+	createKafkaUserListConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize,
 		kafkaUsername1, oldPassword,
 		kafkaUsername2, oldPassword)
-	updateKafkaUserConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
+	updateKafkaUserConfig := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize,
 		kafkaUsername1, newPassword,
 		kafkaUsername2, newPassword)
-	invalidKafkaUserCreateConfigDuplicate := fmt.Sprintf(string(configBytes3), username, apiKey, hostname, zookeeperNodeSize,
+	invalidKafkaUserCreateConfigDuplicate := fmt.Sprintf(string(configBytes5), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize,
 		kafkaUsername1, newPassword,
 		kafkaUsername2, newPassword,
-                kafkaUsername1, newPassword)
-	invalidKafkaUserCreateConfig := fmt.Sprintf(string(configBytes4), username, apiKey, hostname, zookeeperNodeSize,
+                kafkaUsername1, oldPassword)
+	invalidKafkaUserCreateConfig := fmt.Sprintf(string(configBytes4), username, apiKey, hostname, kafkaNodeSize, kafkaVersion, zookeeperNodeSize,
 		kafkaUsername3, oldPassword)
 
 	resource.Test(t, resource.TestCase{

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -1103,7 +1103,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		 */
 		for _, node := range cluster.DataCentres[0].Nodes {
 			nodeSize = node.Size
-			if !strings.HasPrefix(nodeSize, "zk-") {
+			if !strings.HasPrefix(nodeSize, "zk-") && !strings.HasPrefix(nodeSize, "KDZ-") {
 				break
 			}
 		}
@@ -1113,7 +1113,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		rackCount := 0
 		rackList := make([]string, 0)
 		for _, node := range cluster.DataCentres[0].Nodes {
-			if !strings.HasPrefix(node.Size, "zk-") {
+			if !strings.HasPrefix(node.Size, "zk-") && !strings.HasPrefix(node.Size, "KDZ-") {
 				nodeCount += 1
 			}
 			rackList = appendIfMissing(rackList, node.Rack)
@@ -1160,7 +1160,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	for _, dataCentre := range cluster.DataCentres {
 		for _, node := range dataCentre.Nodes {
 			if !stringInSlice(node.Rack, azList) {
-				if !strings.HasPrefix(node.Size, "zk-") {
+				if !strings.HasPrefix(node.Size, "zk-") && !strings.HasPrefix(node.Size, "KDZ-") {
 					azList = appendIfMissing(azList, node.Rack)
 					privateContactPointList = appendIfMissing(privateContactPointList, node.PrivateAddress)
 					publicContactPointList = appendIfMissing(publicContactPointList, node.PublicAddress)

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -1102,7 +1102,8 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		*  Hence, this is a slightly hacky way of ignoring zookeeper node sizes (Kafka bundles specific).
 		 */
 		for _, node := range cluster.DataCentres[0].Nodes {
-			if !isDedicatedZookeeperNodeSize(node.Size) {
+			nodeSize = node.Size
+			if !isDedicatedZookeeperNodeSize(nodeSize) {
 				break
 			}
 		}

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -1412,6 +1412,6 @@ func isClusterSingleDataCentre(cluster Cluster) bool {
 // Currently, there is no API to tell if a node should be included as the main contact point
 // or calculated in the rack allocation scheme (that is not returned by the API).
 // Dedicated ZooKeeper nodes fall into this category and require a specific handling by the provider
-func isDedicatedZookeeperNodeSize(nodeSize String) bool {
+func isDedicatedZookeeperNodeSize(nodeSize string) bool {
 	return strings.HasPrefix(nodeSize, "zk-") || strings.HasPrefix(nodeSize, "KDZ-")
 }

--- a/instaclustr/resource_cluster.go
+++ b/instaclustr/resource_cluster.go
@@ -1413,5 +1413,5 @@ func isClusterSingleDataCentre(cluster Cluster) bool {
 // or calculated in the rack allocation scheme (that is not returned by the API).
 // Dedicated ZooKeeper nodes fall into this category and require a specific handling by the provider
 func isDedicatedZookeeperNodeSize(nodeSize String) bool {
-	return strings.HasPrefix(nodeSize, "zk-") || !strings.HasPrefix(nodeSize, "KDZ-")
+	return strings.HasPrefix(nodeSize, "zk-") || strings.HasPrefix(nodeSize, "KDZ-")
 }

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -76,23 +76,9 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[Error] Cluster %s is not RUNNING. Currently in %s state", cluster_id, cluster.ClusterStatus)
 	}
 
-	// just use linear search for now to check if the user going to be created is already in the system
-	usernameList, err := client.ReadKafkaUserList(cluster_id)
-	if err != nil {
-		return fmt.Errorf("[Error] Error retrieving kafka user list: %s", err)
-	}
-	for _, str := range usernameList {
-		if str == username {
-			// user is already set, so we don't change anything
-			d.SetId(fmt.Sprintf("%s-%s", cluster_id, username))
-			log.Printf("[INFO] Kafka user %s already exists in %s.", username, cluster_id)
-			return nil
-		}
-	}
-
 	createOptionsData := KafkaUserCreateOptions{
 		AuthenticationMechanism: d.Get("authentication_mechanism").(string),
-		OverrideExistingUser: d.Get("override_existing_user").(boolean),
+		OverrideExistingUser: d.Get("override_existing_user").(bool),
 	}
 
 	createData := CreateKafkaUserRequest{

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -50,6 +50,12 @@ func resourceKafkaUser() *schema.Resource {
 				Default: "SCRAM-SHA-256",
 				ForceNew: true,
 			},
+			"override_existing_user": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -86,6 +92,7 @@ func resourceKafkaUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	createOptionsData := KafkaUserCreateOptions{
 		AuthenticationMechanism: d.Get("authentication_mechanism").(string),
+		OverrideExistingUser: d.Get("override_existing_user").(boolean),
 	}
 
 	createData := CreateKafkaUserRequest{

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -206,7 +206,7 @@ type CreateKafkaUserRequest struct {
 
 type KafkaUserCreateOptions struct {
 	AuthenticationMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
-	OverrideExistingUser    bool   `json:"override-existing-user,omitempty" mapstructure:"override-existing-user"`
+	OverrideExistingUser    bool   `json:"override-existing-user" mapstructure:"override-existing-user"`
 }
 
 type UpdateKafkaUserRequest struct {

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -206,6 +206,7 @@ type CreateKafkaUserRequest struct {
 
 type KafkaUserCreateOptions struct {
 	AuthenticationMechanism string `json:"sasl-scram-mechanism,omitempty" mapstructure:"sasl-scram-mechanism"`
+	OverrideExistingUser    bool   `json:"override-existing-user,omitempty" mapstructure:"override-existing-user"`
 }
 
 type UpdateKafkaUserRequest struct {


### PR DESCRIPTION
Internal Reference: INS-16007

To match the API capability for Kafka user creation: override-existing-user option. Removed the checking if user already exists in the Terraform Provider, the ramification is we can't add pre-existing user, e.g., ickafka to the Terraform Provider.