### PR TITLE
INS9222 - Support Multiple CIDRs in VPC Peering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME="terraform-provider-instaclustr"
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.12.1
+VERSION=1.13.0
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Unit tests are within `instaclustr` folder with `_unit_test` suffix, and used to
 
 #### Acceptance Testing
 
-Acceptance tests are within `acc_test` folder, and used to run end-to-end testing. We recommend using CircleCI to run your acceptance tests, however you can run them locally. Acceptance tests require end to end interaction with the instaclustr platform and will create real (paid) infrastructure. If you wish to perform local testing you must set the variables below and run: ```make testacc``` 
+Acceptance tests are within `acc_test` folder, and used to run end-to-end testing. We recommend using CircleCI to run your acceptance tests, however you can run them locally. Acceptance tests require end to end interaction with the Instaclustr platform and will create real (paid) infrastructure. If you wish to perform local testing you must set the variables below and run: ```make testacc``` 
 
 
 Variable | Command | Description

--- a/acc_test/data/valid_with_vpc_peering.tf
+++ b/acc_test/data/valid_with_vpc_peering.tf
@@ -35,5 +35,5 @@ resource "instaclustr_vpc_peering" "valid_with_vpc_peering" {
     cluster_id = "${instaclustr_cluster.valid_with_vpc_peering.cluster_id}"
     peer_vpc_id = "vpc-12345678"
     peer_account_id = "494111121110"
-    peer_subnet = "10.128.176.0/20"
+    peer_subnets = ["10.128.176.0/20", "10.129.176.0/20"]
 }

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -16,7 +16,7 @@ Property | Description | Default
 `cluster_id`|The ID of an existing Instaclustr managed cluster|Required
 `peer_vpc_id`|The ID of the VPC with which you are creating the VPC peering connection|Required
 `peer_account_id`|The account ID of the owner of the accepter VPC|Required
-`peer_subnet`|The subnet for the VPC|Required
+`peer_subnets`|The peer subnets for the VPC|Required
 `peer_region`| The Region code for the accepter VPC, if the accepter VPC is located in a Region other than the Region in which you make the request. | Not Required
 `aws_vpc_connection_id`| The ID of the VPC peering connection. | Computed
 
@@ -27,6 +27,6 @@ resource "instaclustr_vpc_peering" "example_vpc_peering" {
     cluster_id = "${instaclustr_cluster.example.cluster_id}"
     peer_vpc_id = "vpc-123456"
     peer_account_id = "1234567890"
-    peer_subnet = "10.0.0.0/20"
+    peer_subnets = ["10.0.0.0/20", "10.0.32.0/20"]
 }
 ```

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -100,7 +100,7 @@ resource "instaclustr_vpc_peering" "example_vpc_peering" {
   cluster_id = "${instaclustr_cluster.example.id}"
   peer_vpc_id = "vpc-123456"
   peer_account_id = "1234567890"
-  peer_subnet = "10.0.0.0/20"
+  peer_subnets = ["10.0.0.0/20", "10.0.32.0/20"]
 }
 
 // Updating the kafka-schema-registry and the kafka-rest-proxy bundle user passwords at the cluster creation time

--- a/instaclustr/resource_vpc_peering.go
+++ b/instaclustr/resource_vpc_peering.go
@@ -47,8 +47,11 @@ func resourceVpcPeering() *schema.Resource {
 				Required: true,
 			},
 
-			"peer_subnet": {
-				Type:     schema.TypeString,
+			"peer_subnets": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 				Required: true,
 			},
 
@@ -94,7 +97,7 @@ func resourceVpcPeeringCreate(d *schema.ResourceData, meta interface{}) error {
 	createData := CreateVPCPeeringRequest{
 		PeerVpcID:     d.Get("peer_vpc_id").(string),
 		PeerAccountID: d.Get("peer_account_id").(string),
-		PeerSubnet:    d.Get("peer_subnet").(string),
+		PeerSubnets:   d.Get("peer_subnets").([]interface{}),
 		PeerRegion:    d.Get("peer_region").(string),
 	}
 
@@ -144,7 +147,7 @@ func resourceVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("peer_vpc_id", vpcPeering.PeerVpcID)
 	d.Set("peer_account_id", vpcPeering.PeerAccountID)
 	d.Set("aws_vpc_connection_id", vpcPeering.AWSVpcConnectionID)
-	d.Set("peer_subnet", vpcPeering.PeerSubnet)
+	d.Set("peer_subnets", vpcPeering.PeerSubnets)
 	d.Set("peer_region", vpcPeering.PeerRegion)
 
 	log.Printf("[INFO] Fetched VPC peering %s info from the remote server.", vpcPeering.ID)

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -155,22 +155,22 @@ type Node struct {
 }
 
 type CreateVPCPeeringRequest struct {
-	PeerVpcID     string `json:"peerVpcId"`
-	PeerAccountID string `json:"peerAccountId"`
-	PeerSubnet    string `json:"peerSubnet"`
-	PeerRegion    string `json:"peerRegion,omitempty"`
+	PeerVpcID     string        `json:"peerVpcId"`
+	PeerAccountID string        `json:"peerAccountId"`
+	PeerSubnets   []interface{} `json:"peerSubnets"`
+	PeerRegion    string        `json:"peerRegion,omitempty"`
 }
 
 type VPCPeering struct {
-	ID                 string `json:"id"`
-	AWSVpcConnectionID string `json:"aws_vpc_connection_id"`
-	ClusterDataCentre  string `json:"clusterDataCentre"`
-	VpcID              string `json:"vpcId"`
-	PeerVpcID          string `json:"peerVpcId"`
-	PeerAccountID      string `json:"peerAccountId"`
-	PeerSubnet         string `json:"peerSubnet"`
-	StatusCode         string `json:"statusCode"`
-	PeerRegion         string `json:"peerRegion"`
+	ID                 string        `json:"id"`
+	AWSVpcConnectionID string        `json:"aws_vpc_connection_id"`
+	ClusterDataCentre  string        `json:"clusterDataCentre"`
+	VpcID              string        `json:"vpcId"`
+	PeerVpcID          string        `json:"peerVpcId"`
+	PeerAccountID      string        `json:"peerAccountId"`
+	PeerSubnets        []interface{} `json:"peerSubnets"`
+	StatusCode         string        `json:"statusCode"`
+	PeerRegion         string        `json:"peerRegion"`
 }
 
 type VPCPeeringSubnet struct {
@@ -198,10 +198,10 @@ type UpdateBundleUserRequest struct {
 }
 
 type CreateKafkaUserRequest struct {
-	Username           string `json:"username"`
-	Password           string `json:"password"`
-	InitialPermissions string `json:"initial-permissions"`
-	Options KafkaUserCreateOptions `json:"options,omitempty"`
+	Username           string                 `json:"username"`
+	Password           string                 `json:"password"`
+	InitialPermissions string                 `json:"initial-permissions"`
+	Options            KafkaUserCreateOptions `json:"options,omitempty"`
 }
 
 type KafkaUserCreateOptions struct {
@@ -209,9 +209,9 @@ type KafkaUserCreateOptions struct {
 }
 
 type UpdateKafkaUserRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Options	KafkaUserResetPasswordOptions `json:"options,omitempty"`
+	Username string                        `json:"username"`
+	Password string                        `json:"password"`
+	Options  KafkaUserResetPasswordOptions `json:"options,omitempty"`
 }
 
 type KafkaUserResetPasswordOptions struct {

--- a/instaclustr/structs.go
+++ b/instaclustr/structs.go
@@ -173,11 +173,6 @@ type VPCPeering struct {
 	PeerRegion         string        `json:"peerRegion"`
 }
 
-type VPCPeeringSubnet struct {
-	Network      string `json:"network"`
-	PrefixLength string `json:"prefixLength"`
-}
-
 type ResizeClusterRequest struct {
 	NewNodeSize           string       `json:"newNodeSize"`
 	ConcurrentResizes     int          `json:"concurrentResizes"`


### PR DESCRIPTION
These changes are pending API work being released. All tests, and relevant acceptance tests are passing locally - will not pass in CircleCI until the API work has been released.

- Changes to VPC Peering struct to support a list of subnets
- Changes to relevant examples and documentation
- Version bump