### PR TITLE
Fix for cluster dependent resources not forcing new resource on cluster ID change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME=terraform-provider-instaclustr
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.14.3
+VERSION=1.14.2
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME=terraform-provider-instaclustr
 
 
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
-VERSION=1.14.1
+VERSION=1.14.3
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 
 

--- a/instaclustr/resource_firewall_rule.go
+++ b/instaclustr/resource_firewall_rule.go
@@ -13,7 +13,6 @@ func resourceFirewallRule() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceFirewallRuleCreate,
 		Read:   resourceFirewallRuleRead,
-		Update: resourceFirewallRuleUpdate,
 		Delete: resourceFirewallRuleDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -141,10 +140,6 @@ func resourceFirewallRuleStateImport(d *schema.ResourceData, meta interface{}) (
 	d.Set("cluster_id", idParts[0])
 	d.Set("rule_cidr", idParts[1])
 	return []*schema.ResourceData{d}, nil
-}
-
-func resourceFirewallRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
 }
 
 func resourceFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {

--- a/instaclustr/resource_firewall_rule.go
+++ b/instaclustr/resource_firewall_rule.go
@@ -24,20 +24,24 @@ func resourceFirewallRule() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"rule_cidr": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"rule_security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"rules": {
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeMap,
 					Elem: schema.TypeString,

--- a/instaclustr/resource_kafka_user.go
+++ b/instaclustr/resource_kafka_user.go
@@ -23,6 +23,7 @@ func resourceKafkaUser() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"username": {

--- a/instaclustr/resource_vpc_peering.go
+++ b/instaclustr/resource_vpc_peering.go
@@ -30,6 +30,7 @@ func resourceVpcPeering() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"cdc_id": {


### PR DESCRIPTION
The following resources have been updated to force a new resource when the input cluster ID changes -
1. firewall rules
2. VPC peering
3. Kafka users

Internal reference - INS-14611