### PR TITLE
redis 6.2.7 version changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_NAME=terraform-provider-instaclustr
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
 
 
-VERSION=1.27.1
+VERSION=1.27.2
 
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Configuration documentation can be found at the [Instaclustr Terraform Registry]
 | OPENSEARCH               | 1.3.2, 2.0.0                          |                                                                                    |
 | ELASTICSEARCH (For Legacy Support Only)           | 1.13.3                                |                                                                                    |
 | KAFKA_CONNECT            | 2.7.1, 2.8.1, 3.0.0, 3.1.1            |                                                                                    |
-| REDIS                    | 6.0.9                                 |                                                                                    |
+| REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.5.8                                 |                                                                                    |
 | POSTGRESQL               | 13.7, 14.4                            |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |

--- a/acc_test/data/invalid_redis_cluster_create.tf
+++ b/acc_test/data/invalid_redis_cluster_create.tf
@@ -4,7 +4,7 @@ provider "instaclustr" {
   api_hostname = "%s"
 }
 
-resource "instaclustr_cluster" "validRedis" {
+resource "instaclustr_cluster" "invalidRedis" {
   cluster_name            = "tf-redis-test"
   node_size               = "r5.large-100-r"
   data_centre             = "US_WEST_2"
@@ -23,7 +23,7 @@ resource "instaclustr_cluster" "validRedis" {
 
   bundle {
     bundle  = "REDIS"
-    version = "6.0.9"
+    version = "6.2.7"
     options = {
       master_nodes      = 3,
       replica_nodes     = 3,

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -77,7 +77,7 @@ A resource for managing clusters on Instaclustr Managed Platform. A cluster cont
 | OPENSEARCH               | 1.3.2, 2.0.0                          |                                                                                    |
 | ELASTICSEARCH (For Legacy Support Only)           | 1.13.3                                |                                                                                    |
 | KAFKA_CONNECT            | 2.7.1, 2.8.1, 3.0.0, 3.1.1            |                                                                                    |
-| REDIS                    | 6.0.9                                 |                                                                                    |
+| REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.5.8                                 |                                                                                    |
 | POSTGRESQL               | 13.7, 14.4                            |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -362,7 +362,7 @@ resource "instaclustr_cluster" "example-redis" {
 
   bundle {
     bundle = "REDIS"
-    version = "redis:6.0.9"
+    version = "redis:6.2.7"
     options = {
       master_nodes = 3,
       replica_nodes = 3,


### PR DESCRIPTION
while the PCI clusters could be created with Redis version 6.2.7, there are only document changes that are left