### PR TITLE
Updated PostgreSQL versions Q4 2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_NAME=terraform-provider-instaclustr
 # for VERSION, don't add prefix "v", e.g., use "1.9.8" instead of "v1.9.8" as it could break circleCI stuff
 
 
-VERSION=1.27.10
+VERSION=1.27.11
 
 INSTALL_FOLDER=$(HOME)/.terraform.d/plugins/terraform.instaclustr.com/instaclustr/instaclustr/$(VERSION)/darwin_amd64
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Configuration documentation can be found at the [Instaclustr Terraform Registry]
 | KAFKA_CONNECT            | 2.7.1, 2.8.2, 3.0.2, 3.1.2            |                                                                                    |
 | REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.6.3, 3.7.1                          |                                                                                    |
-| POSTGRESQL               | 13.8, 14.5                            |                                                                                    |
+| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deperacated), 14.5 (Deperacated) |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |
 | CADENCE                  | 0.22.4                                |                                                                                    |
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Configuration documentation can be found at the [Instaclustr Terraform Registry]
 | KAFKA_CONNECT            | 2.7.1, 2.8.2, 3.0.2, 3.1.2            |                                                                                    |
 | REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.6.3, 3.7.1                          |                                                                                    |
-| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deperacated), 14.5 (Deperacated) |                                                                                    |
+| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deprecated), 14.5 (Deprecated) |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |
 | CADENCE                  | 0.22.4                                |                                                                                    |
 

--- a/acc_test/data/invalid_postgresql_pgbouncer_cluster_create.tf
+++ b/acc_test/data/invalid_postgresql_pgbouncer_cluster_create.tf
@@ -20,7 +20,7 @@ resource "instaclustr_cluster" "invalidPostgresqlWithPgBouncer" {
 
   bundle {
     bundle  = "POSTGRESQL"
-    version = "14.5"
+    version = "14.6"
     options = {
       postgresql_node_count = 1,
       client_encryption     = false,

--- a/acc_test/data/valid_postgresql_cluster_create.tf
+++ b/acc_test/data/valid_postgresql_cluster_create.tf
@@ -20,7 +20,7 @@ resource "instaclustr_cluster" "validPostgresql" {
 
   bundle {
     bundle = "POSTGRESQL"
-    version = "14.5"
+    version = "14.6"
     options = {
       postgresql_node_count = 2,
       client_encryption = false,

--- a/acc_test/data/valid_postgresql_cluster_with_pgbouncer_create.tf
+++ b/acc_test/data/valid_postgresql_cluster_with_pgbouncer_create.tf
@@ -20,7 +20,7 @@ resource "instaclustr_cluster" "validPostgresqlWithPgBouncer" {
 
   bundle {
     bundle  = "POSTGRESQL"
-    version = "14.5"
+    version = "14.6"
     options = {
       postgresql_node_count = 1,
       client_encryption     = false,

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -79,7 +79,7 @@ A resource for managing clusters on Instaclustr Managed Platform. A cluster cont
 | KAFKA_CONNECT            | 2.7.1, 2.8.2, 3.0.2, 3.1.2            |                                                                                    |
 | REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.6.3, 3.7.1                          |                                                                                    |
-| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deperacated), 14.5 (Deperacated) |                                                                                    |
+| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deprecated), 14.5 (Deprecated) |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |
 | CADENCE                  | 0.22.4                                |                                                                                    |
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -79,7 +79,7 @@ A resource for managing clusters on Instaclustr Managed Platform. A cluster cont
 | KAFKA_CONNECT            | 2.7.1, 2.8.2, 3.0.2, 3.1.2            |                                                                                    |
 | REDIS                    | 6.2.7                                 |                                                                                    |
 | APACHE_ZOOKEEPER         | 3.6.3, 3.7.1                          |                                                                                    |
-| POSTGRESQL               | 13.8, 14.5                            |                                                                                    |
+| POSTGRESQL               | 13.9, 14.6, 15.1 (Public Preview), 13.8 (Deperacated), 14.5 (Deperacated) |                                                                                    |
 | PGBOUNCER                | 1.17.0                                | POSTGRESQL                                                                         |
 | CADENCE                  | 0.22.4                                |                                                                                    |
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -388,7 +388,7 @@ resource "instaclustr_cluster" "example-postgresql" {
 
   bundle {
     bundle = "POSTGRESQL"
-    version = "14.5"
+    version = "14.6"
     options = {
       postgresql_node_count = 2,
       client_encryption = true,


### PR DESCRIPTION
* updated PostgreSQL versions to display new versions and indicate appreciate lifecycles

* Updated test data to use 14.6