### PR TITLE
fix: remove secrets context from forked PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ workflows:
             branches:
               ignore: /.*/
       - build-branches:
-          context: terraform provider
           filters:
             branches:
               only: /.*/


### PR DESCRIPTION
The build-branches job had the 'terraform provider' context attached unnecessarily.

Fixes: INS-41835